### PR TITLE
Mapping filters init

### DIFF
--- a/Source/Common/Processor/Mapping/Filter/MappingFilter.cpp
+++ b/Source/Common/Processor/Mapping/Filter/MappingFilter.cpp
@@ -91,6 +91,14 @@ void MappingFilter::onControllableFeedbackUpdateInternal(ControllableContainer *
 	}
 }
 
+void MappingFilter::onContainerParameterChangedInternal(Parameter *p)
+{
+	if (p == enabled)
+	{
+		mappingFilterAsyncNotifier.addMessage(new FilterEvent(FilterEvent::FILTER_STATE_CHANGED, this));
+	}
+}
+
 Parameter * MappingFilter::process(Parameter * source)
 {
 	if(!enabled->boolValue()) return source; //default or disabled does nothing

--- a/Source/Common/Processor/Mapping/Filter/MappingFilter.cpp
+++ b/Source/Common/Processor/Mapping/Filter/MappingFilter.cpp
@@ -84,7 +84,11 @@ Parameter * MappingFilter::setupParameterInternal(Parameter * source)
 
 void MappingFilter::onControllableFeedbackUpdateInternal(ControllableContainer * cc, Controllable * p)
 {
-	if (cc == &filterParams) filterParamChanged((Parameter *)p);
+	if (cc == &filterParams)
+	{
+		filterParamChanged((Parameter *)p);
+		mappingFilterAsyncNotifier.addMessage(new FilterEvent(FilterEvent::FILTER_PARAM_CHANGED, this));
+	}
 }
 
 Parameter * MappingFilter::process(Parameter * source)

--- a/Source/Common/Processor/Mapping/Filter/MappingFilter.h
+++ b/Source/Common/Processor/Mapping/Filter/MappingFilter.h
@@ -34,6 +34,7 @@ public:
 	virtual Parameter * setupParameterInternal(Parameter * source);
 
 	void onControllableFeedbackUpdateInternal(ControllableContainer *, Controllable * p) override;
+	void onContainerParameterChangedInternal(Parameter *p) override;
 	virtual void filterParamChanged(Parameter * ) {};
 
 	Parameter * process(Parameter * source);
@@ -61,7 +62,7 @@ public:
 
 	class FilterEvent {
 	public:
-		enum Type { FILTER_PARAM_CHANGED };
+		enum Type { FILTER_PARAM_CHANGED, FILTER_STATE_CHANGED };
 		FilterEvent(Type type, MappingFilter * i) : type(type), filter(i) {}
 		Type type;
 		MappingFilter * filter;
@@ -78,6 +79,9 @@ public:
 	virtual String getTypeString() const override { jassert(false); return "[ERROR]"; }
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MappingFilter)
+
+private:
+	JUCE_DECLARE_WEAK_REFERENCEABLE(MappingFilter)
 };
 
 

--- a/Source/Common/Processor/Mapping/Filter/MappingFilterManager.h
+++ b/Source/Common/Processor/Mapping/Filter/MappingFilterManager.h
@@ -15,7 +15,8 @@
 #include "MappingFilter.h"
 
 class MappingFilterManager :
-	public BaseManager<MappingFilter>
+	public BaseManager<MappingFilter>,
+	public MappingFilter::AsyncListener
 {
 public:
 	MappingFilterManager();
@@ -24,7 +25,8 @@ public:
 	Parameter * inputSourceParam;
 	void setupSource(Parameter * source);
 	void rebuildFilterChain();
-	
+	WeakReference<MappingFilter> getLastEnabledFilter() { return lastEnabledFilter; }
+
 	Parameter * processFilters();
 	Factory<MappingFilter> factory;
 
@@ -33,7 +35,12 @@ public:
 	
 	void reorderItems() override;
 
+	void newMessage(const MappingFilter::FilterEvent &e) override;
+
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MappingFilterManager)
+
+protected:
+	WeakReference<MappingFilter> lastEnabledFilter;
 };
 
 

--- a/Source/Common/Processor/Mapping/Mapping.cpp
+++ b/Source/Common/Processor/Mapping/Mapping.cpp
@@ -63,8 +63,8 @@ void Mapping::checkFiltersNeedContinuousProcess()
 void Mapping::updateMappingChain()
 {
 	checkFiltersNeedContinuousProcess();
-	Parameter * p = fm.items.size() > 0 ? fm.items[fm.items.size() - 1]->filteredParameter.get() : input.inputReference;
-	
+	Parameter * p = fm.getLastEnabledFilter() != nullptr ? fm.getLastEnabledFilter()->filteredParameter.get() : input.inputReference;
+
 	if (outputParam == nullptr && p == nullptr) return;
 
 	if (outputParam == nullptr || p == nullptr || outputParam->type != p->type)
@@ -173,7 +173,7 @@ void Mapping::newMessage(const MappingFilterManager::ManagerEvent & e)
 
 void Mapping::filteredParamRangeChanged(MappingFilter * mf)
 {
-	if (fm.items.indexOf(mf) == fm.items.size() - 1)
+	if (mf == fm.getLastEnabledFilter())
 	{
 		//Last item
 		outputParam->setRange(mf->filteredParameter->minimumValue, mf->filteredParameter->maximumValue);

--- a/Source/Common/Processor/Mapping/Mapping.cpp
+++ b/Source/Common/Processor/Mapping/Mapping.cpp
@@ -91,6 +91,8 @@ void Mapping::updateMappingChain()
 	{
 		outputParam->setRange(p->minimumValue, p->maximumValue);
 	}
+
+	process();
 }
 
 void Mapping::process()

--- a/Source/Common/Processor/Mapping/Mapping.cpp
+++ b/Source/Common/Processor/Mapping/Mapping.cpp
@@ -163,7 +163,11 @@ void Mapping::onContainerParameterChangedInternal(Parameter * p)
 
 void Mapping::newMessage(const MappingFilterManager::ManagerEvent & e)
 {
-	if (e.type == MappingFilterManager::ManagerEvent::ITEM_ADDED) e.getItem()->addMappingFilterListener(this);
+	if (e.type == MappingFilterManager::ManagerEvent::ITEM_ADDED)
+	{
+		e.getItem()->addMappingFilterListener(this);
+		e.getItem()->addAsyncFilterListener(this);
+	}
 	updateMappingChain();
 }
 
@@ -176,6 +180,13 @@ void Mapping::filteredParamRangeChanged(MappingFilter * mf)
 	}
 }
 
+void Mapping::newMessage(const MappingFilter::FilterEvent & e)
+{
+	if (e.type == MappingFilter::FilterEvent::FILTER_PARAM_CHANGED)
+	{
+		process();
+	}
+}
 
 ProcessorUI * Mapping::getUI()
 {

--- a/Source/Common/Processor/Mapping/Mapping.cpp
+++ b/Source/Common/Processor/Mapping/Mapping.cpp
@@ -158,6 +158,9 @@ void Mapping::onContainerParameterChangedInternal(Parameter * p)
 	} else if (p == outputParam)
 	{
 		om.setValue(outputParam->getValue());
+	} else if (p == enabled && enabled->boolValue() && !forceDisabled)
+	{
+			process();
 	}
 }
 

--- a/Source/Common/Processor/Mapping/Mapping.h
+++ b/Source/Common/Processor/Mapping/Mapping.h
@@ -22,7 +22,8 @@ class Mapping :
 	public MappingInput::Listener,
 	public Timer,
 	public MappingFilterManager::BaseManager::AsyncListener,
-	public MappingFilter::FilterListener
+	public MappingFilter::FilterListener,
+	public MappingFilter::AsyncListener
 {
 public:
 	Mapping(bool canBeDisabled = true);
@@ -57,6 +58,8 @@ public:
 	void newMessage(const MappingFilterManager::ManagerEvent &e) override;
 
 	void filteredParamRangeChanged(MappingFilter * mf) override;
+
+	void newMessage(const MappingFilter::FilterEvent &e) override;
 
 	virtual void timerCallback() override;
 

--- a/Source/Common/Processor/ProcessorManager.cpp
+++ b/Source/Common/Processor/ProcessorManager.cpp
@@ -92,6 +92,13 @@ void ProcessorManager::checkAllDeactivateActions()
 	}
 }
 
+void ProcessorManager::processAllMappings()
+{
+	Array<Mapping*> mappings = getAllMappings();
+	for (auto &m : mappings)
+		m->process();
+}
+
 void ProcessorManager::loadJSONDataInternal(var data)
 {
 	BaseManager::loadJSONDataInternal(data);

--- a/Source/Common/Processor/ProcessorManager.h
+++ b/Source/Common/Processor/ProcessorManager.h
@@ -34,7 +34,7 @@ public:
 	Array<Mapping *> getAllMappings();
 	void checkAllActivateActions();
 	void checkAllDeactivateActions();
-
+	void processAllMappings();
 
 	Factory<Processor> factory;
 

--- a/Source/StateMachine/State/State.cpp
+++ b/Source/StateMachine/State/State.cpp
@@ -41,6 +41,9 @@ void State::onContainerParameterChangedInternal(Parameter *p)
 			stateListeners.call(&StateListener::stateActivationChanged, this);
 			pm.setForceDisabled(!active->boolValue() || !enabled->boolValue());
 
+			if (enabled->boolValue() && active->boolValue())
+				pm.processAllMappings();
+				
 		} else if(enabled->boolValue())
 		{
 			if (active->boolValue())
@@ -49,6 +52,7 @@ void State::onContainerParameterChangedInternal(Parameter *p)
 				stateListeners.call(&StateListener::stateActivationChanged, this);
 
 				pm.checkAllActivateActions();
+				pm.processAllMappings();
 			} else
 			{
 				pm.checkAllDeactivateActions();


### PR DESCRIPTION
Here is a set of changes concerning mappings inside states, when working with mostly static variables. 
I found that most of the time the values were not properly initialized. 

Mappings are now processed when :
- filters are created, deleted and reordered
- filter parameters are edited
- filters are enabled / disabled (including setting the output range if needed)
- mappings are enabled (if the input value has changed while the mapping was disabled)
- states are enabled or activated (idem)

This is my first real dive into the code so please excuse any bad pratice or whatever and tell me if you need corrections !

Also, you might want to change the tooltip for the enable button in Organic UI EnablingControllableContainer, it looks a bit outdated ;)