### PR TITLE
Fix MIDI feedback : Serialize / deserialize MIDI values as a special type

### DIFF
--- a/Source/Module/ModuleManager.cpp
+++ b/Source/Module/ModuleManager.cpp
@@ -15,6 +15,7 @@
 #include "CustomVariables/CVGroupManager.h"
 #include "Module/modules/customvariables/CustomVariablesModule.h"
 #include "ChataigneEngine.h"
+#include "Module/modules/midi/MIDIModule.h"
 
 juce_ImplementSingleton(ModuleManager)
 
@@ -24,6 +25,8 @@ ModuleManager::ModuleManager() :
 	itemDataType = "Module";
 	helpID = "Modules";
 	showInspectorOnSelect = false;
+
+	ControllableFactory::getInstance()->controllableDefs.add(new ControllableDefinition(MIDIValueParameter::getTypeStringStatic(), &MIDIValueParameter::create));
 }
 
 ModuleManager::~ModuleManager()

--- a/Source/Module/modules/midi/MIDIModule.h
+++ b/Source/Module/modules/midi/MIDIModule.h
@@ -29,9 +29,30 @@ public:
 
 	~MIDIValueParameter() {}
 
+	var getJSONDataInternal() override
+	{
+		var data = IntParameter::getJSONDataInternal();
+		data.getDynamicObject()->setProperty("channel", channel);
+		data.getDynamicObject()->setProperty("pitchOrNumber", pitchOrNumber);
+		data.getDynamicObject()->setProperty("MIDIType", type);
+		return data;
+	}
+
+	void loadJSONDataInternal(var data) override
+	{
+		Parameter::loadJSONDataInternal(data);
+		channel = data.getProperty("channel", false);
+		pitchOrNumber = data.getProperty("pitchOrNumber", false);
+		type = static_cast<Type>((int)data.getProperty("MIDIType", false));
+	}
+
 	Type type;
 	int channel;
 	int pitchOrNumber;
+
+	static MIDIValueParameter * create() { return new MIDIValueParameter("New MIDI Value Parameter", "", 0, 0, 0, NOTE_ON); }
+	virtual String getTypeString() const override { return getTypeStringStatic(); }
+	static String getTypeStringStatic() { return "MIDI Value"; }
 };
 
 class MIDIModule :


### PR DESCRIPTION
I've added the factory definition for the new controllable type in the ModuleManager as it's the first singleton in the hierarchy. Tell me if you think that there is a better way to do it !

Older projects should load fine but the existing Values won't be usable for MIDI feedback. Any value added with "Auto add" or manually should work.
