### PR TITLE
OSC module : send messages from a separate thread

### DIFF
--- a/Source/Module/modules/osc/OSCModule.h
+++ b/Source/Module/modules/osc/OSCModule.h
@@ -15,7 +15,8 @@
 using namespace servus;
 
 class OSCOutput :
-	public BaseItem
+	public BaseItem,
+	public Thread
 {
 public:
 	OSCOutput();
@@ -28,16 +29,21 @@ public:
 	BoolParameter * useLocal;
 	StringParameter * remoteHost;
 	IntParameter * remotePort;
-	OSCSender sender;
 
 	void setForceDisabled(bool value);
 
 	virtual void setupSender();
 	void sendOSC(const OSCMessage & m);
 
+	virtual void run() override;
+
 	void onContainerParameterChangedInternal(Parameter * p) override;
 
 	virtual InspectableEditor * getEditor(bool isRoot) override;
+
+private:
+	OSCSender sender;
+	std::queue<OSCMessage> messageQueue;
 };
 
 class OSCModule :


### PR DESCRIPTION
Hello Ben,

I have run into a issue on Linux (and probably mac OS as well), where the OS may delay the UDP writes if the target address is on the network subnet, but unreachable. 

This is documented in JUCE : https://docs.juce.com/master/classDatagramSocket.html#a24df3d574d38f78256551c1f58d58be1

In practice, this can cause the main thread to hang : 
![Peek 08-09-2020 11-45](https://user-images.githubusercontent.com/5353407/92494644-3dd77280-f1f6-11ea-9c8d-1effaecd7428.gif)

Here is a proposal to fix this. The messages are sent to a separate thread for each OSC output. 
Let me know if you see any error or if you think that this behaviour should be implemented in other modules and if it should be more generic. 
