### PR TITLE
Various fixes on Serial module and DMX (OpenDMX & Enttec Pro) module

### DIFF
--- a/Source/Common/DMX/device/DMXDevice.cpp
+++ b/Source/Common/DMX/device/DMXDevice.cpp
@@ -33,7 +33,7 @@ DMXDevice::DMXDevice(const String& name, Type _type, bool canReceive) :
 	outputCC = new EnablingControllableContainer("Output");
 	addChildControllableContainer(outputCC, true);
 	alwaysSend = outputCC->addBoolParameter("Always Send", "If checked, the device will always send the stored values to the constant rate set by the target rate parameter.\nIf you experience some lags, try unchecking this option.", true);
-	targetRate = outputCC->addIntParameter("Target send rate", "If fixed rate is checked, this is the frequency in Hz of the sending rate", 40, 1, 100);
+	targetRate = outputCC->addIntParameter("Target send rate", "If fixed rate is checked, this is the frequency in Hz of the sending rate", 40, 1, 20000);
 	
 	if (alwaysSend->boolValue()) startTimer(1000/targetRate->intValue());
 }

--- a/Source/Common/DMX/device/DMXDevice.h
+++ b/Source/Common/DMX/device/DMXDevice.h
@@ -37,6 +37,7 @@ public:
 	IntParameter * targetRate;
 
 	void setConnected(bool value);
+	virtual void refreshEnabled() {};
 
 	virtual void sendDMXValue(int channel, int value);
 	virtual void sendDMXRange(int startChannel, Array<int> values);

--- a/Source/Common/DMX/device/DMXEnttecProDevice.cpp
+++ b/Source/Common/DMX/device/DMXEnttecProDevice.cpp
@@ -33,7 +33,6 @@ void DMXEnttecProDevice::setPortConfig()
 	dmxPort->writeBytes(getSerialNumberBytes);
 
 	dmxPort->port->write(changeAlwaysData, 6); //to avoid blocking the dmxPro on send
-
 }
 
 void DMXEnttecProDevice::sendDMXValuesSerialInternal()
@@ -45,7 +44,7 @@ void DMXEnttecProDevice::sendDMXValuesSerialInternal()
     }
     
 	dmxPort->port->write(sendHeaderData, 5);
-	dmxPort->port->write(dmxDataOut, 512);
+	dmxPort->port->write(dmxDataOut, dmxChannels);
 	dmxPort->port->write(sendFooterData, 1);
 	dmxPort->port->flush();
 
@@ -58,6 +57,11 @@ void DMXEnttecProDevice::sendDMXValuesSerialInternal()
 	if(inputCC->enabled->boolValue()) dmxPort->port->write(changeAlwaysData, 6); //to avoid blocking the dmxPro on send
 }
 
+void DMXEnttecProDevice::changeDMXChannels()
+{
+	sendHeaderData[2] = (dmxChannels + 1) & 255;
+	sendHeaderData[3] = ((dmxChannels + 1) >> 8) & 255;
+}
 
 
 void DMXEnttecProDevice::serialDataReceived(const var& data)

--- a/Source/Common/DMX/device/DMXEnttecProDevice.h
+++ b/Source/Common/DMX/device/DMXEnttecProDevice.h
@@ -42,6 +42,8 @@ public:
 	void setPortConfig() override;
 	void sendDMXValuesSerialInternal() override;
 
+	void changeDMXChannels() override;
+
 	void serialDataReceived(const var &data) override;
 	Array<uint8> getDMXPacket(Array<uint8> bytes, int &endIndex);
 	void processDMXPacket(Array<uint8> bytes);

--- a/Source/Common/DMX/device/DMXOpenUSBDevice.cpp
+++ b/Source/Common/DMX/device/DMXOpenUSBDevice.cpp
@@ -75,7 +75,7 @@ void DMXOpenUSBDevice::sendDMXValuesSerialInternal()
 		dmxPort->port->setBreak(true);
 	    dmxPort->port->setBreak(false);
 	    dmxPort->port->write(startCode, 1); //start code
-		dmxPort->port->write(dmxDataOut, 512);
+		dmxPort->port->write(dmxDataOut, dmxChannels);
 	}
 	catch (serial::IOException e)
 	{

--- a/Source/Common/DMX/device/DMXSerialDevice.h
+++ b/Source/Common/DMX/device/DMXSerialDevice.h
@@ -20,8 +20,12 @@ public:
 	DMXSerialDevice(const String &name, Type type, bool canReceive);
 	virtual ~DMXSerialDevice();
 
+	bool setPortStatus(bool status);
+
 	SerialDeviceParameter * portParam;
 	SerialDevice * dmxPort;
+	IntParameter * channelsParam;
+	int dmxChannels = 512;
 
 	//Device info
 	String deviceID;
@@ -29,6 +33,10 @@ public:
 
 	void setCurrentPort(SerialDevice * port);
 	virtual void setPortConfig() {}
+
+	void refreshEnabled() override;
+
+	virtual void changeDMXChannels() {};
 
 	virtual void processIncomingData();
 

--- a/Source/Common/Serial/SerialDevice.cpp
+++ b/Source/Common/Serial/SerialDevice.cpp
@@ -180,7 +180,10 @@ void SerialDevice::addSerialDeviceListener(SerialDeviceListener * newListener) {
 
 void SerialDevice::removeSerialDeviceListener(SerialDeviceListener * listener) {
 	listeners.remove(listener);
-	if (listeners.size() == 0) SerialManager::getInstance()->removePort(this);
+	if (listeners.size() == 0) {
+		SerialManager* manager = SerialManager::getInstance();
+		manager->removePort(this);
+	}
 }
 
 SerialReadThread::SerialReadThread(String name, SerialDevice * _port) :

--- a/Source/Module/modules/dmx/DMXModule.cpp
+++ b/Source/Module/modules/dmx/DMXModule.cpp
@@ -213,7 +213,10 @@ void DMXModule::onContainerParameterChanged(Parameter* p)
 	Module::onContainerParameterChanged(p);
 	if (p == enabled)
 	{
-		if (dmxDevice != nullptr) dmxDevice->enabled = enabled->boolValue();
+		if (dmxDevice != nullptr) {
+			dmxDevice->enabled = enabled->boolValue();
+			dmxDevice->refreshEnabled();
+		}
 	}
 }
 

--- a/Source/Module/modules/serial/SerialModule.h
+++ b/Source/Module/modules/serial/SerialModule.h
@@ -19,6 +19,8 @@ public:
 	SerialModule(const String &name = "Serial");
 	virtual ~SerialModule();
 
+	bool setPortStatus(bool status);
+
 	//Device info
 	String deviceID;
 	String lastOpenedPortID; //for ghosting


### PR DESCRIPTION
Hello,
Here's my very first contribution to Chataigne!

This PR contains a little rework of the serial opening and closing functions, with the following fixes and additions:
Serial module:
 * Fixed port reopening on device hotplug even if the module was disabled (that was very frustration while working with an Arduino ;) )
 * Fixed crashing when opening an invalid/busy port and disconnecting it
 * Fixed "Is Connected" checkbox not updating when module is turned off
 * Maybe more that I don't remember

DMX module (OpenDMX & Enttec Pro):
 * Sames fixes as Serial
 * Port is now closing when module is disabled/opening when re-enabled
 * Added a max DMX channel option (reduces DMX/Entecc protocol message lenght to improve performance and be able to increase the send rate)
![image](https://user-images.githubusercontent.com/21125429/118316405-13f9ec80-b4f7-11eb-9f19-ed11d25cdeba.png)

It probably need some testing especially on Linux & MacOs (on Windows Serial works fine, but I did not test OpenDmx/Entecc pro yet).