### PR TITLE
Add a precision setting for Serial "Send values" function

### DIFF
--- a/Source/Common/Command/BaseCommand.cpp
+++ b/Source/Common/Command/BaseCommand.cpp
@@ -153,6 +153,8 @@ void BaseCommand::setupTemplateParameters(CommandTemplate* ct)
 		//create customValuesTemplateManager
 		ct->customValuesManager.reset(new CustomValuesCommandArgumentManager(context == MAPPING, true, multiplex));
 		ct->customValuesManager->allowedTypes.addArray(customValuesManager->allowedTypes);
+		ct->customValuesManager->enablePrecison = customValuesManager->enablePrecison;
+		ct->customValuesManager->createParamCallbackFunc = customValuesManager->createParamCallbackFunc;
 		ct->addChildControllableContainer(ct->customValuesManager.get());
 	}
 }

--- a/Source/Common/Command/CustomValues/CustomValuesCommandArgument.h
+++ b/Source/Common/Command/CustomValues/CustomValuesCommandArgument.h
@@ -19,14 +19,18 @@ class CustomValuesCommandArgument :
 	public MultiplexTarget
 {
 public:
-	CustomValuesCommandArgument(const String& name = "arg", Parameter* p = nullptr, bool mappingEnabled = false, bool templateMode = false, Multiplex * multiplex = nullptr);
+	CustomValuesCommandArgument(const String& name = "arg", Parameter* p = nullptr, bool mappingEnabled = false, bool templateMode = false, Multiplex * multiplex = nullptr, bool enablePrecison = true);
 	virtual ~CustomValuesCommandArgument();
 
 	Parameter * param;
 	BoolParameter * editable;
+	EnumParameter * sendPrecision;
+
+	enum IntType {INT32, INT16, BYTE};
 
 	bool mappingEnabled;
 	bool templateMode;
+	bool enablePrecison;
 
 	std::unique_ptr<ParameterLink> paramLink;
 

--- a/Source/Common/Command/CustomValues/CustomValuesCommandArgumentManager.cpp
+++ b/Source/Common/Command/CustomValues/CustomValuesCommandArgumentManager.cpp
@@ -11,14 +11,15 @@
 #include "CustomValuesCommandArgumentManager.h"
 #include "ui/CustomValuesCommandArgumentManagerEditor.h"
 
-CustomValuesCommandArgumentManager::CustomValuesCommandArgumentManager(bool _mappingEnabled, bool templateMode, Multiplex * multiplex) :
+CustomValuesCommandArgumentManager::CustomValuesCommandArgumentManager(bool _mappingEnabled, bool templateMode, Multiplex* multiplex) :
 	BaseManager("arguments"),
 	MultiplexTarget(multiplex),
 	isBeingDestroyed(false),
-    mappingEnabled(_mappingEnabled),
-    templateMode(templateMode),
-    linkedTemplateManager(nullptr),
-	createParamCallbackFunc(nullptr)
+	mappingEnabled(_mappingEnabled),
+	templateMode(templateMode),
+	linkedTemplateManager(nullptr),
+	createParamCallbackFunc(nullptr),
+	enablePrecison(true)
 {
 	selectItemWhenCreated = false;
 	editorCanBeCollapsed = false;
@@ -109,7 +110,7 @@ void CustomValuesCommandArgumentManager::removeItemInternal(CustomValuesCommandA
 
 CustomValuesCommandArgument * CustomValuesCommandArgumentManager::addItemWithParam(Parameter * p, var data, bool fromUndoableAction)
 {
-	CustomValuesCommandArgument* a = new CustomValuesCommandArgument("#" + String(items.size() + 1), p, mappingEnabled, templateMode, multiplex);
+	CustomValuesCommandArgument* a = new CustomValuesCommandArgument("#" + String(items.size() + 1), p, mappingEnabled, templateMode, multiplex, enablePrecison);
 	//a->addArgumentListener(this);
 	addItem(a, data, fromUndoableAction);
 

--- a/Source/Common/Command/CustomValues/CustomValuesCommandArgumentManager.h
+++ b/Source/Common/Command/CustomValues/CustomValuesCommandArgumentManager.h
@@ -24,6 +24,7 @@ public:
 	bool isBeingDestroyed; //to keep track for templates, do not sync on destroy, so we can keep a ghost
 	bool mappingEnabled;
 	bool templateMode;
+	bool enablePrecison;
 
 	Array<Controllable::Type> allowedTypes;
 

--- a/Source/Common/Command/CustomValues/ui/CustomValuesCommandArgumentEditor.cpp
+++ b/Source/Common/Command/CustomValues/ui/CustomValuesCommandArgumentEditor.cpp
@@ -20,6 +20,12 @@ CustomValuesCommandArgumentEditor::CustomValuesCommandArgumentEditor(CustomValue
 		addAndMakeVisible(editableUI.get());
 	}
 
+	if (arg->sendPrecision != nullptr)
+	{
+		sendPrecisionUI.reset(arg->sendPrecision->createUI());
+		addAndMakeVisible(sendPrecisionUI.get());
+	}
+
 	if (arg->paramLink != nullptr)
 	{
 		paramUI.reset(new LinkableParameterEditor(arg->paramLink.get(), arg->mappingEnabled));

--- a/Source/Common/Command/CustomValues/ui/CustomValuesCommandArgumentEditor.h
+++ b/Source/Common/Command/CustomValues/ui/CustomValuesCommandArgumentEditor.h
@@ -24,6 +24,7 @@ public:
 
 	std::unique_ptr<InspectableEditor> paramUI;
 	std::unique_ptr<BoolToggleUI> editableUI;
+	std::unique_ptr<EnumParameterUI> sendPrecisionUI;
 
 	void resizedInternalHeader(Rectangle<int> &r) override;
 	void resizedInternalContent(Rectangle<int> &r) override;

--- a/Source/Module/modules/common/streaming/commands/SendStreamRawDataCommand.cpp
+++ b/Source/Module/modules/common/streaming/commands/SendStreamRawDataCommand.cpp
@@ -13,6 +13,7 @@ SendStreamRawDataCommand::SendStreamRawDataCommand(StreamingModule* _module, Com
 {
 	customValuesManager->allowedTypes.add(Controllable::INT);
 	customValuesManager->createParamCallbackFunc = std::bind(&SendStreamRawDataCommand::customValueCreated, this, std::placeholders::_1, std::placeholders::_2);
+	customValuesManager->enablePrecison = false;
 }
 
 SendStreamRawDataCommand::~SendStreamRawDataCommand()

--- a/Source/Module/modules/common/streaming/commands/SendStreamValuesCommand.cpp
+++ b/Source/Module/modules/common/streaming/commands/SendStreamValuesCommand.cpp
@@ -49,7 +49,20 @@ void SendStreamValuesCommand::triggerInternal(int multiplexIndex)
 		switch (p->type)
 		{
 		case Controllable::BOOL: data.writeBool(val);
-		case Controllable::INT: data.writeInt(val); break;
+		case Controllable::INT:
+			switch (a->sendPrecision->getValueDataAsEnum<CustomValuesCommandArgument::IntType>())
+			{
+				case CustomValuesCommandArgument::INT16:
+					data.writeShort((int)val);
+					break;
+				case CustomValuesCommandArgument::BYTE:
+					data.writeByte((int)val);
+					break;
+				default:
+					data.writeInt(val);
+					break;
+			}
+			break;
 		case Controllable::FLOAT: data.writeFloat(val); break;
 		case Controllable::STRING: data.writeString(val); break;
 


### PR DESCRIPTION
This PR contains the following changes:
 * Added an option to choose the int precision for Int arguments in Serial module "Send values" function
![image](https://user-images.githubusercontent.com/21125429/119157455-7e5de000-ba55-11eb-9ebc-6be9b814129e.png)
  This removes the need for the "send raw bytes" function, but it's still here for now
 * Fixed the send raw byte not constraining/showing as hex in template editor
![image](https://user-images.githubusercontent.com/21125429/119157920-f3c9b080-ba55-11eb-8114-1a6763b489e8.png)

I tried to do the modifications as close as possible as the "Chataigne style", but I'm really opened to discussion if you'd prefer other ways to implement this!