### PR TITLE
Temporary (or not) fix for DMXEnttecPro input crash

### DIFF
--- a/Source/Common/DMX/device/DMXEnttecProDevice.cpp
+++ b/Source/Common/DMX/device/DMXEnttecProDevice.cpp
@@ -67,8 +67,14 @@ void DMXEnttecProDevice::changeDMXChannels()
 void DMXEnttecProDevice::serialDataReceived(const var& data)
 {
 	if (!inputCC->enabled->boolValue()) return;
+	if (!data.isBinaryData()) {
+		dmxPort->setMode(SerialDevice::PortMode::RAW);
+		return;
+	}
 
-	serialBuffer.addArray((const uint8_t*)data.getBinaryData()->getData(), (int)data.getBinaryData()->getSize());
+	MemoryBlock * binaryData = data.getBinaryData();
+
+	serialBuffer.addArray((const uint8_t *)binaryData->getData(), (int)binaryData->getSize());
 
 	int endIndex = 0;
 	Array<uint8> packet = getDMXPacket(serialBuffer, endIndex);


### PR DESCRIPTION
I have absolutely no idea why this is happening but even while forcing:
```C
dmxPort->setMode(SerialDevice::PortMode::RAW);
```
in `setPortConfig()` function for example, the dmxPort is somehow going back to `SerialDevice::PortMode::STRING` somewhere after initialization...
This little addition ensures that the data is a byte array, and if not set back the mode to RAW and end the function (else the `getBinaryData()` fails and the app crashes).

From my debugging the `if (!data.isBinaryData()) {` only triggers once after enabling input, so only the first received packet is lost.

If you have an explanation for why this is happening, there would probably be a better fix, but for now this is working great.