### PR TITLE
Fix for internal serial port on linux

### DIFF
--- a/Source/Common/Serial/lib/serial/impl/list_ports/list_ports_linux.cc
+++ b/Source/Common/Serial/lib/serial/impl/list_ports/list_ports_linux.cc
@@ -183,8 +183,14 @@ get_sysfs_info(const string& device_path)
 
         string sys_id_path = sys_device_path + "/id";
 
-        if( path_exists( sys_id_path ) )
+        if( path_exists( sys_id_path ) ){
             hardware_id = read_line( sys_id_path );
+			if(hardware_id.compare(0,3,"PNP") == 0){ //ACPI port
+				hardware_id = "ACPI=0000:" + hardware_id.substring(3, 7);
+			}else{
+				hardware_id = "PCI=" + hardware_id;
+			}
+		}
     }
 
     if( friendly_name.empty() )


### PR DESCRIPTION
Because of this code in the SerialDeviceInfo class:
https://github.com/benkuper/Chataigne/blob/2bfd54e01e6f2b174f44a53ea2ad24cb9c205c91/Source/Common/Serial/SerialDevice.cpp#L301-L312
Every other port than USB ones are ignored because their name does not correspond to the correct formatting.
The integrated RS232 port of the Dell workstation I'm currently working on is showing up like this:
```bash
#cat /sys/class/tty/ttyS0/device/id
PNP0501
```
It probably means Plug and Play, I've red somewhere it's controlled by ACPI (can't find where anymore).
I'm assuming that a normal PCI `device/id` would be in the format `PID:VID`, but I have no way to test as I don't have any PCIe serial card on hand.

Note: this is untested as I don't have any way to compile on Linux right now