### PR TITLE
Fix for DMX Serial not openning on project loading

### DIFF
--- a/Source/Common/DMX/device/DMXSerialDevice.cpp
+++ b/Source/Common/DMX/device/DMXSerialDevice.cpp
@@ -29,9 +29,11 @@ DMXSerialDevice::~DMXSerialDevice()
 	setCurrentPort(nullptr);
 }
 
-bool DMXSerialDevice::setPortStatus(bool status) {
+bool DMXSerialDevice::setPortStatus(bool status)
+{
 
-	if (dmxPort == nullptr) {
+	if (dmxPort == nullptr)
+	{
 		setConnected(false);
 		return false;
 	}
@@ -73,6 +75,8 @@ void DMXSerialDevice::refreshEnabled()
 void DMXSerialDevice::setCurrentPort(SerialDevice* port)
 {
 	if (dmxPort == port) return;
+
+	setPortStatus(false);
 
 	if (dmxPort != nullptr)
 	{
@@ -118,7 +122,6 @@ void DMXSerialDevice::onContainerParameterChanged(Parameter* p)
 
 	if (p == portParam)
 	{
-		setPortStatus(false);
 		SerialDevice* newDevice = portParam->getDevice();
 		SerialDevice* prevPort = dmxPort;
 		setCurrentPort(newDevice);

--- a/Source/Module/modules/serial/SerialModule.cpp
+++ b/Source/Module/modules/serial/SerialModule.cpp
@@ -74,6 +74,8 @@ void SerialModule::setCurrentPort(SerialDevice* _port)
 {
 	if (port == _port) return;
 
+	setPortStatus(false);
+
 	if (port != nullptr)
 	{
 		port->removeSerialDeviceListener(this);
@@ -123,7 +125,6 @@ void SerialModule::onControllableFeedbackUpdateInternal(ControllableContainer* c
 	}
 	if (c == portParam)
 	{
-		setPortStatus(false);
 		SerialDevice* newDevice = portParam->getDevice();
 		SerialDevice* prevPort = port;
 		setCurrentPort(newDevice);


### PR DESCRIPTION
Small fix that prevents the DMX devices from opening and then immediately closing on project loading (took me 1h of debugging to find the issue!).