### PR TITLE
Fix for random crashes while loading at large project at start

### DIFF
--- a/Source/Module/Community/CommunityModuleInfo.h
+++ b/Source/Module/Community/CommunityModuleInfo.h
@@ -18,12 +18,15 @@ public:
 	CommunityModuleInfo(StringRef name = "", var moduleData = var());
 	~CommunityModuleInfo();
 
+	enum CommunityModuleStatus {INSTALLED, NEW_VERSION_AVAILABLE, UP_TO_DATE, NOT_INSTALLED};
+
 	String url;
 	String description;
 	String downloadURL;
 	String onlineVersion;
 	String localVersion;
 	File localModuleFolder;
+	CommunityModuleStatus status;
 
 	std::unique_ptr<URL::DownloadTask> downloadTask;
 

--- a/Source/Module/Community/CommunityModuleManager.cpp
+++ b/Source/Module/Community/CommunityModuleManager.cpp
@@ -28,6 +28,9 @@ CommunityModuleManager::~CommunityModuleManager()
 void CommunityModuleManager::run()
 {
 	wait(500);
+
+	DBG("Started loading community modules");
+
 	var data = getJSONDataForURL(URL("https://benjamin.kuperberg.fr/chataigne/releases/modules.json"));
 	
 	if (threadShouldExit()) return;
@@ -69,12 +72,11 @@ void CommunityModuleManager::run()
 	}
 	
 	LOG("Finished fetching Community modules.");
-	ModuleManager::getInstance()->factory->updateCustomModules(false);
 
 	bool showUpdate = false;
 	for (auto& i : items)
 	{
-		if (i->onlineVersion > i->localVersion)
+		if (i->status == CommunityModuleInfo::NEW_VERSION_AVAILABLE)
 		{
 			showUpdate = true;
 			break;

--- a/Source/Module/ModuleFactory.cpp
+++ b/Source/Module/ModuleFactory.cpp
@@ -126,10 +126,7 @@ void ModuleFactory::addCustomModulesInFolder(File folder, bool isLocal, bool log
 				{
 					if (CommunityModuleInfo* info = CommunityModuleManager::getInstance()->getModuleInfoForFolder(m))
 					{
-						if (info->onlineVersion > info->localVersion)
-						{
-							def->newVersionAvailable = true;
-						}
+						info->updateLocalData();
 					}
 				}
 
@@ -157,6 +154,14 @@ var ModuleFactory::getCustomModuleInfo(StringRef moduleName)
 {
 	if (!customModulesDefMap.contains(moduleName)) return var();
 	return customModulesDefMap[moduleName]->customModuleData;
+}
+
+void ModuleFactory::setModuleNewVersionAvailable(StringRef moduleName, bool newVersionAvailable)
+{
+	if (customModulesDefMap.contains(moduleName))
+	{
+		customModulesDefMap[moduleName]->newVersionAvailable = newVersionAvailable;
+	}
 }
 
 File ModuleFactory::getFolderForCustomModule(StringRef moduleName) const

--- a/Source/Module/ModuleFactory.h
+++ b/Source/Module/ModuleFactory.h
@@ -44,6 +44,7 @@ public:
 	void addCustomModulesInFolder(File folder, bool isLocal, bool log = true);
 	void updateCustomModules(bool log = true);
 	var getCustomModuleInfo(StringRef moduleName);
+	void setModuleNewVersionAvailable(StringRef moduleName, bool newVersionAvailable);
 	File getFolderForCustomModule(StringRef moduleName) const;
 	File getCustomModulesFolder() const;
 


### PR DESCRIPTION
### What is happening?
While loading a large project at the start of Chataigne (via command line or via Global Settings) with custom modules used in it, if the time to load the project is greater than the time to fetch community modules list from the web, Chataigne might crash.
On a specific project I had this happening ~1/3 times while loading.

### Why is it happening?
When the community module fetch function finishes its job, it is calling: 
```C++
ModuleManager::getInstance()->factory->updateCustomModules(false);
```
Which is reloading all custom modules, presumably to update the `newVersionAvailable` boolean variable for each module to indicate if a new version is available or not.
However if Chataigne is still loading a project, the `updateCustomModules` function temporally breaks references to custom modules and so Chataigne crashes.

### What was changed in this PR
Instead of calling `updateCustomModules` to check for available updates, the version checking is now all done on the community modules fetcher thread, and only the `newVersionAvailable` variable is updated for each module at the end instead of reloading all modules.