### PR TITLE
Fix for sACN warnings

### DIFF
--- a/Source/Common/DMX/device/DMXSACNDevice.cpp
+++ b/Source/Common/DMX/device/DMXSACNDevice.cpp
@@ -173,6 +173,7 @@ void DMXSACNDevice::run()
 			continue;
 		}
 
+		receivedSeq = receivedPacket.frame.seq_number;
 		
 		int universe = ((receivedPacket.frame.universe >> 8) & 0xFF) | ((receivedPacket.frame.universe & 0xFF) << 8);
 		if (universe == inputUniverse->intValue())


### PR DESCRIPTION
Simple fix for sACN warnings and dropped packets

The receivedSeq variable was never updated and so every packet with number 0 was discarded.