### PR TITLE
Add support for Stream Deck MK.2

### DIFF
--- a/Source/Module/modules/controller/streamdeck/StreamDeckManager.cpp
+++ b/Source/Module/modules/controller/streamdeck/StreamDeckManager.cpp
@@ -122,6 +122,7 @@ StreamDeck* StreamDeckManager::openDevice(hid_device_info* deviceInfo)
 		break;
 
 	case PID_V2:
+	case PID_MK2:
 		cd = new StreamDeckV2(d, String(deviceInfo->serial_number));
 		break;
 

--- a/Source/Module/modules/controller/streamdeck/StreamDeckManager.h
+++ b/Source/Module/modules/controller/streamdeck/StreamDeckManager.h
@@ -21,7 +21,7 @@ public:
 
 	const int vid = 4057;
 	
-	enum StreamDeckPID { PID_MINI = 0x63, PID_V1 = 0x60, PID_V2 = 0x6D, PID_XL = 0x6C};
+	enum StreamDeckPID { PID_MINI = 0x63, PID_V1 = 0x60, PID_V2 = 0x6D, PID_MK2 = 0x80, PID_XL = 0x6C};
 
 	OwnedArray<StreamDeck> devices;
 


### PR DESCRIPTION
**Not tested because I don't own a Stream Deck, but based on other libraries:**
https://github.com/abcminiuser/python-elgato-streamdeck/commit/5076c7503e591bf5da9fe661ec9fca5bf2917bb5
https://github.com/unix-streamdeck/driver/commit/ac16a1fdd5ecc6f9a45823d8e64a35fffa307a65
Stream Deck MK.2 is a new version of the Stream Deck V2, with differences in the casing but, from what I found in other projects, not in the software.