### PR TITLE
fix load value of dynamic values of scripted module

### DIFF
--- a/Source/Module/Module.cpp
+++ b/Source/Module/Module.cpp
@@ -172,8 +172,8 @@ var Module::getJSONData()
 
 void Module::loadJSONDataItemInternal(var data)
 {
-	if (includeValuesInSave) valuesCC.loadJSONData(data.getProperty(valuesCC.shortName, var()), true);
 	moduleParams.loadJSONData(data.getProperty("params", var())); //keep "params" to avoid conflict with container's parameter
+	if (includeValuesInSave) valuesCC.loadJSONData(data.getProperty(valuesCC.shortName, var()), true);
 	templateManager->loadJSONData(data.getProperty(templateManager->shortName, var()), true);
 }
 


### PR DESCRIPTION
I created a script module that dynamically creates N values dynamically, that the user can set, depending on a "count" parameter.
aka moduleParameterChanged calls local.values.addIntParameter.

The value of dynamic values is saved but not loaded because the values do not exist yet, because the parameters are not loaded yet.
Loading parameters first will trigger the script's scriptParameterChanged that may be responsible for creating dynamic values. Then value of created values will load just fine.

Also it seems for natural to load "parameters" before "values".

It's maybe a risk to invert the load behavior though.
I found this previous commit "4d3c843 - load values before templates and scripts" that moved the load values at the front of the function, but the message suggests the point was to move it before "templates", not "parameters".

I let you decide if it worth it or not...