### PR TITLE
add "route all" trigger to module router

### DIFF
--- a/Source/Module/Routing/ModuleRouter.cpp
+++ b/Source/Module/Routing/ModuleRouter.cpp
@@ -20,6 +20,7 @@ ModuleRouter::ModuleRouter() :
 	sourceValues.userCanAddItemsManually = false;
 	selectAllValues = addTrigger("Select All", "Select all values for routing");
 	deselectAllValues = addTrigger("Deselect All", "Deselect all values");
+	routeAllValues = addTrigger("Route All", "Immediately trigger all enabled routes");
 
 	addChildControllableContainer(&sourceValues);
 }
@@ -187,6 +188,16 @@ void ModuleRouter::onContainerTriggerTriggered(Trigger * t)
 		for (auto &sv : sourceValues.items)
 		{
 			sv->enabled->setValue(t == selectAllValues);
+		}
+	}
+	else if (t == routeAllValues)
+	{
+		for (auto& v : sourceValues.items)
+		{
+			if (v->enabled->value)
+			{
+				v->outModule->handleRoutedModuleValue(v->sourceValue, v->routeParams.get());
+			}
 		}
 	}
 }

--- a/Source/Module/Routing/ModuleRouter.h
+++ b/Source/Module/Routing/ModuleRouter.h
@@ -32,6 +32,7 @@ public:
 
 	Trigger * selectAllValues;
 	Trigger * deselectAllValues;
+	Trigger * routeAllValues;
 
 	void setSourceModule(Module * m);
 	void setDestModule(Module * m);

--- a/Source/Module/Routing/ui/ModuleRouterView.cpp
+++ b/Source/Module/Routing/ui/ModuleRouterView.cpp
@@ -94,6 +94,7 @@ void ModuleRouterView::resized()
 	selectAllTrigger->setBounds(sr.removeFromLeft(50));
 	sr.removeFromLeft(4);
 	deselectAllTrigger->setBounds(sr);
+	routeAllTrigger->setBounds(sr);
 
 	outParamsLabel.setBounds(outr);
 
@@ -128,6 +129,8 @@ void ModuleRouterView::setRouter(ModuleRouter * router)
 		selectAllTrigger.reset();
 		removeChildComponent(deselectAllTrigger.get());
 		deselectAllTrigger.reset();
+		removeChildComponent(routeAllTrigger.get());
+		routeAllTrigger.reset();
 
 		removeChildComponent(&sourceChooser);
 		removeChildComponent(&destChooser);
@@ -157,8 +160,10 @@ void ModuleRouterView::setRouter(ModuleRouter * router)
 
 		selectAllTrigger.reset(currentRouter->selectAllValues->createButtonUI());
 		deselectAllTrigger.reset(currentRouter->deselectAllValues->createButtonUI());
+		routeAllTrigger.reset(currentRouter->routeAllValues->createButtonUI());
 		addAndMakeVisible(selectAllTrigger.get());
 		addAndMakeVisible(deselectAllTrigger.get());
+		addAndMakeVisible(routeAllTrigger.get());
 
 	} else
 	{

--- a/Source/Module/Routing/ui/ModuleRouterView.h
+++ b/Source/Module/Routing/ui/ModuleRouterView.h
@@ -28,6 +28,7 @@ public:
 
 	std::unique_ptr<TriggerButtonUI> selectAllTrigger;
 	std::unique_ptr<TriggerButtonUI> deselectAllTrigger;
+	std::unique_ptr<TriggerButtonUI> routeAllTrigger;
 
 	ModuleChooserUI sourceChooser;
 	ModuleChooserUI destChooser;


### PR DESCRIPTION
I have a case where several devices talk OSC to a server. Chataigne takes over at some point but has no way to know the state of the server. With this new feature, you may force Chataigne to send all values of a given router to initialize the server the way it wants.