### PR TITLE
JoyCon input jitter threshold

### DIFF
--- a/Source/Module/modules/controller/joycon/JoyConModule.cpp
+++ b/Source/Module/modules/controller/joycon/JoyConModule.cpp
@@ -20,6 +20,9 @@ JoyConModule::JoyConModule() :
 
 	reconnectControllers = moduleParams.addTrigger("Reconnect Controllers", "If the controllers were not powered on at initialization, then you can connect by clicking here");
 
+	useJitterThreshold = moduleParams.addBoolParameter("Use Jitter Threshold", "Only send accel/orentiation/stick changes if the delta is greater than the jitter threshold.", true);
+	jitterThreshold = moduleParams.addFloatParameter("Jitter Threshold", "Delta change threshold for analog inputs. Only update values if the change is greater than the threshold.", 0.005, 0.0, 0.1, true);
+
 	leftAccel = leftValues.addPoint3DParameter("Left Accel", "");
 	leftAccel->setBounds(-1, -1, -1, 1, 1, 1);
 	leftOrientation = leftValues.addPoint3DParameter("Left Orientation", "");
@@ -99,6 +102,8 @@ void JoyConModule::updateController(int controller)
 	JOY_SHOCK_STATE state = JslGetSimpleState(controller);
 	MOTION_STATE motion = JslGetMotionState(controller);
 
+	float tmpThreshold = jitterThreshold->getValue();
+
 	if (type == 1)
 	{
 		up->setValue((state.buttons >> 0) & 1);
@@ -115,37 +120,46 @@ void JoyConModule::updateController(int controller)
 		leftSL->setValue((state.buttons >> 18) & 1);
 		leftSR->setValue((state.buttons >> 19) & 1);
 
-		float tmpX = abs(lastLeftAccelX - motion.accelX);
-		float tmpY = abs(lastLeftAccelY - motion.accelY);
-		float tmpZ = abs(lastLeftAccelZ - motion.accelZ);
+		tmpDeltaX = abs(lastLeftAccelX - motion.accelX);
+		tmpDeltaY = abs(lastLeftAccelY - motion.accelY);
+		tmpDeltaZ = abs(lastLeftAccelZ - motion.accelZ);
 
-		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+		if (useJitterThreshold->getValue() && (tmpDeltaX > tmpThreshold || tmpDeltaY > tmpThreshold || tmpDeltaZ > tmpThreshold)) {
 			lastLeftAccelX = motion.accelX;
 			lastLeftAccelY = motion.accelY;
 			lastLeftAccelZ = motion.accelZ;
 
 			leftAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
 		}
+		else if(!useJitterThreshold->getValue()) {
+			leftAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
+		}
 
-		tmpX = abs(lastLeftOrientationX - motion.gravX);
-		tmpY = abs(lastLeftOrientationY - motion.gravY);
-		tmpZ = abs(lastLeftOrientationZ - motion.gravZ);
+		tmpDeltaX = abs(lastLeftOrientationX - motion.gravX);
+		tmpDeltaY = abs(lastLeftOrientationY - motion.gravY);
+		tmpDeltaZ = abs(lastLeftOrientationZ - motion.gravZ);
 
-		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+		if (useJitterThreshold->getValue() && (tmpDeltaX > tmpThreshold || tmpDeltaY > tmpThreshold || tmpDeltaZ > tmpThreshold)) {
 			lastLeftOrientationX = motion.gravX;
 			lastLeftOrientationY = motion.gravY;
 			lastLeftOrientationZ = motion.gravZ;
 
 			leftOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
 		}
+		else if (!useJitterThreshold->getValue()) {
+			leftOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
+		}
 
-		tmpX = abs(lastLeftAxisX - state.stickLX);
-		tmpY = abs(lastLeftAxisY - state.stickLY);
+		tmpDeltaX = abs(lastLeftAxisX - state.stickLX);
+		tmpDeltaY = abs(lastLeftAxisY - state.stickLY);
 
-		if (tmpX > jitterThreshold || tmpY > jitterThreshold) {
+		if (useJitterThreshold->getValue() && (tmpDeltaX > tmpThreshold || tmpDeltaY > tmpThreshold)) {
 			lastLeftAxisX = state.stickLX;
 			lastLeftAxisY = state.stickLY;
 
+			leftAxis->setPoint(state.stickLX, state.stickLY);
+		}
+		else if (!useJitterThreshold->getValue()) {
 			leftAxis->setPoint(state.stickLX, state.stickLY);
 		}
 		
@@ -166,39 +180,50 @@ void JoyConModule::updateController(int controller)
 		rightSL->setValue((state.buttons >> 18) & 1);
 		rightSR->setValue((state.buttons >> 19) & 1);
 
-		float tmpX = abs(lastRightAccelX - motion.accelX);
-		float tmpY = abs(lastRightAccelY - motion.accelY);
-		float tmpZ = abs(lastRightAccelZ - motion.accelZ);
+		tmpDeltaX = abs(lastRightAccelX - motion.accelX);
+		tmpDeltaY = abs(lastRightAccelY - motion.accelY);
+		tmpDeltaZ = abs(lastRightAccelZ - motion.accelZ);
 
-		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+		if (useJitterThreshold->getValue() && (tmpDeltaX > tmpThreshold || tmpDeltaY > tmpThreshold || tmpDeltaZ > tmpThreshold)) {
 			lastRightAccelX = motion.accelX;
 			lastRightAccelY = motion.accelY;
 			lastRightAccelZ = motion.accelZ;
 
 			leftAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
 		}
+		else if (!useJitterThreshold->getValue()) {
+			leftAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
+		}
 
-		tmpX = abs(lastRightOrientationX - motion.gravX);
-		tmpY = abs(lastRightOrientationY - motion.gravY);
-		tmpZ = abs(lastRightOrientationZ - motion.gravZ);
+		tmpDeltaX = abs(lastRightOrientationX - motion.gravX);
+		tmpDeltaY = abs(lastRightOrientationY - motion.gravY);
+		tmpDeltaZ = abs(lastRightOrientationZ - motion.gravZ);
 
-		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+		if (useJitterThreshold->getValue() && (tmpDeltaX > tmpThreshold || tmpDeltaY > tmpThreshold || tmpDeltaZ > tmpThreshold)) {
 			lastRightOrientationX = motion.gravX;
 			lastRightOrientationY = motion.gravY;
 			lastRightOrientationZ = motion.gravZ;
 
 			rightOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
 		}
+		else if (!useJitterThreshold->getValue()) {
+			rightOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
+		}
 
-		tmpX = abs(lastRightAxisX - state.stickLX);
-		tmpY = abs(lastRightAxisY - state.stickLY);
 
-		if (tmpX > jitterThreshold || tmpY > jitterThreshold) {
+		tmpDeltaX = abs(lastRightAxisX - state.stickLX);
+		tmpDeltaY = abs(lastRightAxisY - state.stickLY);
+
+		if (useJitterThreshold->getValue() && (tmpDeltaX > tmpThreshold || tmpDeltaY > tmpThreshold)) {
 			lastRightAxisX = state.stickLX;
 			lastRightAxisY = state.stickLY;
 
 			rightAxis->setPoint(state.stickLX, state.stickLY);
 		}
+		else if (!useJitterThreshold->getValue()) {
+			rightAxis->setPoint(state.stickLX, state.stickLY);
+		}
+
 	}
 }
 

--- a/Source/Module/modules/controller/joycon/JoyConModule.cpp
+++ b/Source/Module/modules/controller/joycon/JoyConModule.cpp
@@ -115,10 +115,40 @@ void JoyConModule::updateController(int controller)
 		leftSL->setValue((state.buttons >> 18) & 1);
 		leftSR->setValue((state.buttons >> 19) & 1);
 
-		leftAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
-		leftOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
+		float tmpX = abs(lastLeftAccelX - motion.accelX);
+		float tmpY = abs(lastLeftAccelY - motion.accelY);
+		float tmpZ = abs(lastLeftAccelZ - motion.accelZ);
 
-		leftAxis->setPoint(state.stickLX, state.stickLY);
+		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+			lastLeftAccelX = motion.accelX;
+			lastLeftAccelY = motion.accelY;
+			lastLeftAccelZ = motion.accelZ;
+
+			leftAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
+		}
+
+		tmpX = abs(lastLeftOrientationX - motion.gravX);
+		tmpY = abs(lastLeftOrientationY - motion.gravY);
+		tmpZ = abs(lastLeftOrientationZ - motion.gravZ);
+
+		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+			lastLeftOrientationX = motion.gravX;
+			lastLeftOrientationY = motion.gravY;
+			lastLeftOrientationZ = motion.gravZ;
+
+			leftOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
+		}
+
+		tmpX = abs(lastLeftAxisX - state.stickLX);
+		tmpY = abs(lastLeftAxisY - state.stickLY);
+
+		if (tmpX > jitterThreshold || tmpY > jitterThreshold) {
+			lastLeftAxisX = state.stickLX;
+			lastLeftAxisY = state.stickLY;
+
+			leftAxis->setPoint(state.stickLX, state.stickLY);
+		}
+		
 	} else if (type == 2)
 	{
 		plus->setValue((state.buttons >> 4) & 1);
@@ -136,10 +166,39 @@ void JoyConModule::updateController(int controller)
 		rightSL->setValue((state.buttons >> 18) & 1);
 		rightSR->setValue((state.buttons >> 19) & 1);
 
-		rightAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
-		rightOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
+		float tmpX = abs(lastRightAccelX - motion.accelX);
+		float tmpY = abs(lastRightAccelY - motion.accelY);
+		float tmpZ = abs(lastRightAccelZ - motion.accelZ);
 
-		rightAxis->setPoint(state.stickRX, state.stickRY);
+		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+			lastRightAccelX = motion.accelX;
+			lastRightAccelY = motion.accelY;
+			lastRightAccelZ = motion.accelZ;
+
+			leftAccel->setVector(motion.accelX, motion.accelY, motion.accelZ);
+		}
+
+		tmpX = abs(lastRightOrientationX - motion.gravX);
+		tmpY = abs(lastRightOrientationY - motion.gravY);
+		tmpZ = abs(lastRightOrientationZ - motion.gravZ);
+
+		if (tmpX > jitterThreshold || tmpY > jitterThreshold || tmpZ > jitterThreshold) {
+			lastRightOrientationX = motion.gravX;
+			lastRightOrientationY = motion.gravY;
+			lastRightOrientationZ = motion.gravZ;
+
+			rightOrientation->setVector(motion.gravX, motion.gravY, motion.gravZ);
+		}
+
+		tmpX = abs(lastRightAxisX - state.stickLX);
+		tmpY = abs(lastRightAxisY - state.stickLY);
+
+		if (tmpX > jitterThreshold || tmpY > jitterThreshold) {
+			lastRightAxisX = state.stickLX;
+			lastRightAxisY = state.stickLY;
+
+			rightAxis->setPoint(state.stickLX, state.stickLY);
+		}
 	}
 }
 

--- a/Source/Module/modules/controller/joycon/JoyConModule.h
+++ b/Source/Module/modules/controller/joycon/JoyConModule.h
@@ -27,7 +27,22 @@ public:
 	ControllableContainer leftValues;
 	ControllableContainer rightValues;
 
+    // JoyCon usually jitters +/-0.02. When learning inputs the controller jitter is really cumbersome.
+	const float jitterThreshold = 0.03;
+
 	//Left controller
+
+	float lastLeftAccelX = 0.0;
+	float lastLeftAccelY = 0.0;
+	float lastLeftAccelZ = 0.0;
+
+	float lastLeftOrientationX = 0.0;
+	float lastLeftOrientationY = 0.0;
+	float lastLeftOrientationZ = 0.0;
+
+	float lastLeftAxisX = 0.0;
+	float lastLeftAxisY = 0.0;
+
 	Point3DParameter* leftAccel;
 	Point3DParameter* leftOrientation;
 	Point2DParameter * leftAxis;
@@ -44,6 +59,17 @@ public:
 	BoolParameter *  minus;
 
 	//Right controller
+	float lastRightAccelX = 0.0;
+	float lastRightAccelY = 0.0;
+	float lastRightAccelZ = 0.0;
+
+	float lastRightOrientationX = 0.0;
+	float lastRightOrientationY = 0.0;
+	float lastRightOrientationZ = 0.0;
+
+	float lastRightAxisX = 0.0;
+	float lastRightAxisY = 0.0;
+
 	Point3DParameter* rightAccel;
 	Point3DParameter * rightOrientation;
 	Point2DParameter * rightAxis;

--- a/Source/Module/modules/controller/joycon/JoyConModule.h
+++ b/Source/Module/modules/controller/joycon/JoyConModule.h
@@ -21,14 +21,20 @@ public:
 	~JoyConModule();
 
 	Trigger* reconnectControllers;
+
+	BoolParameter* useJitterThreshold;
+	FloatParameter* jitterThreshold;
+
 	Array<int> controllers;
 	SpinLock controllerLock;
 
 	ControllableContainer leftValues;
 	ControllableContainer rightValues;
 
-    // JoyCon usually jitters +/-0.02. When learning inputs the controller jitter is really cumbersome.
-	const float jitterThreshold = 0.03;
+	// Temp deltas for jitter suppression
+	float tmpDeltaX;
+	float tmpDeltaY;
+	float tmpDeltaZ;
 
 	//Left controller
 


### PR DESCRIPTION
Added option "Jitter Threshold" which gives the user an option to only update JoyCon values when they change by a configured delta amount. This is helpful when learning inputs so the JoyCon constantly changing values don't automatically get learned for every [learn] click.