### PR TITLE
Working router with new DMX universe functionallity

### DIFF
--- a/Source/Module/modules/dmx/DMXModule.h
+++ b/Source/Module/modules/dmx/DMXModule.h
@@ -86,16 +86,19 @@ public:
 		public RouteParams
 	{
 	public:
-		DMXRouteParams(Module* sourceModule, Controllable* c);
+		DMXRouteParams(Module* sourceModule, Controllable* c, DMXUniverseManager& outputUniverseManager);
 		~DMXRouteParams() {}
 
 		EnumParameter* mode16bit;
 		BoolParameter* fullRange;
 		IntParameter* channel;
+        TargetParameter* dmxUniverse;
 
 	};
 
-	virtual RouteParams* createRouteParamsForSourceValue(Module* sourceModule, Controllable* c, int /*index*/) override { return new DMXRouteParams(sourceModule, c); }
+	virtual RouteParams* createRouteParamsForSourceValue(Module* sourceModule, Controllable* c, int /*index*/) override {
+        return new DMXRouteParams(sourceModule, c, outputUniverseManager);
+    }
 	virtual void handleRoutedModuleValue(Controllable* c, RouteParams* p) override;
 
 
@@ -106,6 +109,7 @@ public:
 		DMXModuleRouterController(ModuleRouter* router);
 
 		Trigger* autoSetChannels;
+        Trigger* autoSetUniverse;
 
 		void triggerTriggered(Trigger* t) override;
 	};


### PR DESCRIPTION
Make router works with new DMX universe functionallity (Only for INT, FLOAT and BOOL parameters)

- We can select the wanted universe for each router line
- We can set that all the router lines take the first universe in the associated DMX Module

Waiting to add the DMX Module from Blux to add the others (Point 2D, Point 3D, Color)