### PR TITLE
Add support for StreamDeck XL new PID

### DIFF
--- a/Source/Module/modules/controller/streamdeck/StreamDeckManager.cpp
+++ b/Source/Module/modules/controller/streamdeck/StreamDeckManager.cpp
@@ -127,6 +127,7 @@ StreamDeck* StreamDeckManager::openDevice(hid_device_info* deviceInfo)
 		break;
 
 	case PID_XL:
+	case PID_XL_V2:
 		cd = new StreamDeckXL(d, String(deviceInfo->serial_number));
 		break;
 

--- a/Source/Module/modules/controller/streamdeck/StreamDeckManager.h
+++ b/Source/Module/modules/controller/streamdeck/StreamDeckManager.h
@@ -21,7 +21,7 @@ public:
 
 	const int vid = 4057;
 	
-	enum StreamDeckPID { PID_MINI = 0x63, PID_V1 = 0x60, PID_V2 = 0x6D, PID_MK2 = 0x80, PID_XL = 0x6C};
+	enum StreamDeckPID { PID_MINI = 0x63, PID_V1 = 0x60, PID_V2 = 0x6D, PID_MK2 = 0x80, PID_XL = 0x6C, PID_XL_V2 = 0x8F};
 
 	OwnedArray<StreamDeck> devices;
 


### PR DESCRIPTION
Solving issue #171

I don' have the hardware on hand to test, but according to others projects the new Deck XL is identical to the older one, with just a new PID.

Ref: https://github.com/abcminiuser/python-elgato-streamdeck/commit/263882ea9e9710a0922e203705afc4366506848b