### PR TITLE
Fix MIDI lag and disconnect on module disable

### DIFF
--- a/Source/Common/MIDI/MIDIDevice.cpp
+++ b/Source/Common/MIDI/MIDIDevice.cpp
@@ -132,7 +132,7 @@ void MIDIOutputDevice::close()
 	if (usageCount == 0)
 	{
 		device = nullptr;
-		LOG("MIDI In " << name << " closed");
+		LOG("MIDI Out " << name << " closed");
 	}
 }
 

--- a/Source/Common/MIDI/MIDIManager.cpp
+++ b/Source/Common/MIDI/MIDIManager.cpp
@@ -179,8 +179,3 @@ MIDIOutputDevice* MIDIManager::getOutputDeviceWithName(const String& name)
 	for (auto& d : outputs) if (d->name == name) return d;
 	return nullptr;
 }
-
-void MIDIManager::timerCallback()
-{
-	checkDevices();
-}

--- a/Source/Common/MIDI/MIDIManager.cpp
+++ b/Source/Common/MIDI/MIDIManager.cpp
@@ -18,7 +18,6 @@ MIDIManager::MIDIManager()
 	midiRouterDefaultType = dynamic_cast<ChataigneEngine*>(Engine::mainEngine)->defaultBehaviors.addEnumParameter("MIDI Router Ouput Type", "Choose the default type when choosing a MIDI Module as Router output");
 	midiRouterDefaultType->addOption("Control Change", MIDIManager::CONTROL_CHANGE)->addOption("Note On", MIDIManager::NOTE_ON)->addOption("Note Off", MIDIManager::NOTE_OFF);
 
-	startTimer(500); //check devices each half seconds
 	checkDevices();
 }
 

--- a/Source/Common/MIDI/MIDIManager.h
+++ b/Source/Common/MIDI/MIDIManager.h
@@ -10,8 +10,7 @@
 
 #pragma once
 
-class MIDIManager :
-	public Timer
+class MIDIManager
 {
 public:
 	juce_DeclareSingleton(MIDIManager, true)
@@ -55,19 +54,15 @@ public:
 	void removeMIDIManagerListener(Listener* listener) { listeners.remove(listener); }
 
 
-
-	// Inherited via Timer
-	virtual void timerCallback() override;
-
 	static String getNoteName(const int& pitch, bool includeOctave = true, int octaveShift = 0)
 	{
 		return MidiMessage::getMidiNoteName(pitch, true, includeOctave, 3 - octaveShift);
 	}
 
 	MidiDeviceListConnection connection = MidiDeviceListConnection::make ([this]
-    {
+	{
         checkDevices();
-    });
+	});
 
 	JUCE_DECLARE_NON_COPYABLE(MIDIManager)
 };

--- a/Source/Common/MIDI/MIDIManager.h
+++ b/Source/Common/MIDI/MIDIManager.h
@@ -64,5 +64,10 @@ public:
 		return MidiMessage::getMidiNoteName(pitch, true, includeOctave, 3 - octaveShift);
 	}
 
+	MidiDeviceListConnection connection = MidiDeviceListConnection::make ([this]
+    {
+        checkDevices();
+    });
+
 	JUCE_DECLARE_NON_COPYABLE(MIDIManager)
 };

--- a/Source/Module/modules/midi/MIDIModule.cpp
+++ b/Source/Module/modules/midi/MIDIModule.cpp
@@ -297,11 +297,23 @@ void MIDIModule::onControllableFeedbackUpdateInternal(ControllableContainer* cc,
 	}
 }
 
+void MIDIModule::onContainerParameterChangedInternal(Parameter* p)
+{
+	Module::onContainerParameterChangedInternal(p);
+	if (p == enabled){
+		updateMIDIDevices();
+	}
+}
+
 void MIDIModule::updateMIDIDevices()
 {
-	MIDIInputDevice* newInput = midiParam->inputDevice;
-	//if (inputDevice != newInput)
-	//{
+	MIDIInputDevice* newInput = nullptr;
+	MIDIOutputDevice* newOutput = nullptr;
+	if (enabled->boolValue()){
+		newInput = midiParam->inputDevice;
+		newOutput = midiParam->outputDevice;
+	}
+
 	if (inputDevice != nullptr)
 	{
 		inputDevice->removeMIDIInputListener(this);
@@ -317,11 +329,7 @@ void MIDIModule::updateMIDIDevices()
 		mtcReceiver->addMTCListener(this);
 		noteOns.clear();
 	}
-	//}
 
-	MIDIOutputDevice* newOutput = midiParam->outputDevice;
-	//if (outputDevice != newOutput)
-	//{
 	if (outputDevice != nullptr)
 	{
 		if (sendClock->boolValue()) outClock.setOutDevice(nullptr);

--- a/Source/Module/modules/midi/MIDIModule.h
+++ b/Source/Module/modules/midi/MIDIModule.h
@@ -151,6 +151,7 @@ public:
 	void sendMidiMachineControlGoto(int hours, int minutes, int seconds, int frames);
 
 	void onControllableFeedbackUpdateInternal(ControllableContainer* cc, Controllable* c) override;
+	virtual void onContainerParameterChangedInternal(Parameter* p) override;
 	void updateMIDIDevices();
 
 	virtual void noteOnReceived(const int& channel, const int& pitch, const int& velocity) override;


### PR DESCRIPTION
# 1. Fixing lag caused by MIDI on Linux #208
I finally found it!
The issue is mainly caused by [this addition to JUCE](https://github.com/benkuper/JUCE/commit/26a872ba9f8375125499b97e8b46726da24457be#diff-2dd746dcdee8bc7040ed9240174fa2240ab70b783fd15872714b42e850594ae3R257-R281).
The timeout is happening [here](https://github.com/benkuper/JUCE/blob/26a872ba9f8375125499b97e8b46726da24457be/modules/juce_audio_devices/native/juce_linux_Midi.cpp#L356).

Each time `MidiInput::getAvailableDevices()` or `MidiOutput::getAvailableDevices()` is called, a new connection to Alsa is created to listen to system announcements. This operations often times out (100ms delay) when done too frequently and when no midi device is connected (for some reasons beyond my understanding) which creates a lag. It would probably be quite hard to avoid that without big rework on the JUCE code...

Fortunately JUCE added at the same time as this modification a much better option than polling every 500ms for new MIDI devices!
(see [the demo](https://github.com/juce-framework/JUCE/blob/master/examples/Audio/MidiDemo.h#L479) for an example)
I implemented it and it works just fine for me on Linux, might need some testing on other OS but as it is used in the official demo and is quite straightforward to use hopefully it will work just fine.

# 2. Disconnect MIDI device when module is disabled
A simple modification to make the MIDI devices automatically connect/disconnect when the module is enabled/disabled like others modules already do.