### PR TITLE
fix preset value with the "none" interpolation mode is actually applied

### DIFF
--- a/Source/CustomVariables/CVGroup.cpp
+++ b/Source/CustomVariables/CVGroup.cpp
@@ -97,7 +97,10 @@ void CVGroup::setValuesToPreset(CVPreset* preset)
 		Parameter* p = dynamic_cast<Parameter*>(v->controllable);
 		if (p == nullptr) continue;
 		ParameterPreset* pp = preset->values.getParameterPresetForSource(p);
-		if (pp != nullptr) p->setValue(pp->parameter->value);
+		if (pp == nullptr) continue;
+		const ParameterPreset::InterpolationMode mode = pp->interpolationMode->getValueDataAsEnum<ParameterPreset::InterpolationMode>();
+		if (mode == ParameterPreset::NONE) continue;
+		p->setValue(pp->parameter->value);
 	}
 }
 


### PR DESCRIPTION
The interpolation mode is only tested when using "go to" (aka lerp) preset but is ignored if simply applied.
It makes sense for all interpolation modes, except for "none" that should do nothing too.
