### PR TITLE
Add new string comparisons

### DIFF
--- a/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.cpp
+++ b/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.cpp
@@ -11,14 +11,38 @@
 StringComparator::StringComparator(Parameter *sourceParam, Multiplex* multiplex) :
 	BaseComparator(multiplex)
 {
-	setReferenceParam(new StringParameter("Reference", "Comparison Reference to check against source value", sourceParam->stringValue()));
+    setupReferenceParam();
 	reference->setValue(sourceParam->stringValue(), false, true, true);
 
 	addCompareOption("=", equalsId);
 	addCompareOption("!=", differentId);
+
 	addCompareOption("Contains", containsId);
-	addCompareOption("Starts with", startsWith);
-	addCompareOption("Ends with", endsWidth);
+	addCompareOption("Contains (ignoring case)", containsIgnoreCaseId);
+
+	addCompareOption("Does not contain", notContainsId);
+	addCompareOption("Does not contain (ignoring case)", notContainsIgnoreCaseId);
+
+	addCompareOption("Matches regexp", regexpMatchesId);
+	addCompareOption("Does not match regexp", notRegexpMatchesId);
+
+	addCompareOption("Length is", lengthIsId);
+	addCompareOption("Length is not", lengthIsNotId);
+	addCompareOption("Length is less than", lengthShorterThanId);
+	addCompareOption("Length is greater than", lengthLongerThanId);
+
+	addCompareOption("Starts with", startsWithId);
+	addCompareOption("Starts with (ignoring case)", startsWithIgnoreCaseId);
+
+	addCompareOption("Does not start with", notStartsWithId);
+	addCompareOption("Does not start with (ignoring case)", notStartsWithIgnoreCaseId);
+
+	addCompareOption("Ends with", endsWithId);
+	addCompareOption("Ends with (ignoring case)", endsWithIgnoreCaseId);
+
+	addCompareOption("Does not end with", notEndsWithId);
+	addCompareOption("Does not end with (ignoring case)", notEndsWithIgnoreCaseId);
+
 	addCompareOption("Change", changeId);
 }
 
@@ -26,14 +50,97 @@ StringComparator::~StringComparator()
 {
 }
 
+void StringComparator::compareFunctionChanged()
+{
+	setupReferenceParam();
+}
+
+
+void StringComparator::setupReferenceParam()
+{
+	if (currentFunctionId.toString().contains("length"))
+	{
+	    int defaultValue = 0;
+        if (reference != nullptr && reference->type == Parameter::INT)
+        {
+            defaultValue = reference->intValue();
+        }
+		setReferenceParam(new IntParameter("Reference", "Comparison Reference to check against source value", defaultValue, 0,INT32_MAX));
+	} else {
+        String defaultValue = "";
+	    if (reference != nullptr && reference->type == Parameter::STRING)
+    	{
+    	    defaultValue = reference->stringValue();
+    	}
+    	setReferenceParam(new StringParameter("Reference", "Comparison Reference to check against source value", defaultValue));
+	}
+}
+
+
 bool StringComparator::compareInternal(Parameter* sourceParam, int multiplexIndex)
 {
 	String value = isMultiplexed() ? refLink->getLinkedValue(multiplexIndex).toString() : reference->stringValue();
 
-	if (currentFunctionId == equalsId)				return sourceParam->stringValue() == value;
-	else if (currentFunctionId == differentId)		return sourceParam->stringValue() != value;
-	else if (currentFunctionId == containsId)		return sourceParam->stringValue().contains(value);
-	else if (currentFunctionId == startsWith)		return sourceParam->stringValue().startsWith(value);
-	else if (currentFunctionId == endsWidth)		return sourceParam->stringValue().endsWith(value);
+
+	if (currentFunctionId == equalsId)				            return sourceParam->stringValue() == value;
+	else if (currentFunctionId == differentId)		            return sourceParam->stringValue() != value;
+
+	else if (currentFunctionId == containsId)		            return sourceParam->stringValue().contains(value);
+	else if (currentFunctionId == containsIgnoreCaseId)		    return sourceParam->stringValue().containsIgnoreCase(value);
+
+	else if (currentFunctionId == notContainsId)	            return !sourceParam->stringValue().contains(value);
+	else if (currentFunctionId == notContainsIgnoreCaseId)	    return !sourceParam->stringValue().containsIgnoreCase(value);
+
+    // @TODO: Add UI that enables setting the flags string value (or checkboxes). (See third parameter).
+    // If it is complicated, we could copy PHP's/sed's way of doing it by specifying regexp with wildcard:   #fooregexp#im.
+	else if (currentFunctionId == regexpMatchesId)		        return StringComparator::regexpMatch(value,sourceParam->stringValue(),"");
+	else if (currentFunctionId == notRegexpMatchesId)		    return !StringComparator::regexpMatch(value,sourceParam->stringValue(),"");
+
+	else if (currentFunctionId == lengthIsId)	                return sourceParam->stringValue().length()==value.getIntValue();
+	else if (currentFunctionId == lengthIsNotId)	            return sourceParam->stringValue().length()!=value.getIntValue();
+	else if (currentFunctionId == lengthLongerThanId)	        return sourceParam->stringValue().length()>value.getIntValue();
+	else if (currentFunctionId == lengthShorterThanId)	        return sourceParam->stringValue().length()<value.getIntValue();
+
+	else if (currentFunctionId == startsWithId)		            return sourceParam->stringValue().startsWith(value);
+	else if (currentFunctionId == startsWithIgnoreCaseId)	    return sourceParam->stringValue().startsWithIgnoreCase(value);
+
+	else if (currentFunctionId == notStartsWithId)	            return !sourceParam->stringValue().startsWith(value);
+	else if (currentFunctionId == notStartsWithIgnoreCaseId)    return !sourceParam->stringValue().startsWithIgnoreCase(value);
+
+	else if (currentFunctionId == endsWithId)		            return sourceParam->stringValue().endsWith(value);
+	else if (currentFunctionId == endsWithIgnoreCaseId)		    return sourceParam->stringValue().endsWithIgnoreCase(value);
+
+	else if (currentFunctionId == notEndsWithId)	            return !sourceParam->stringValue().endsWith(value);
+	else if (currentFunctionId == notEndsWithIgnoreCaseId)	    return !sourceParam->stringValue().endsWithIgnoreCase(value);
+
 	return false;
+}
+
+/** Checks if the given string matches the regex wildcard with the specified flags. */
+bool  StringComparator::regexpMatch(const juce::String& regexpString, const juce::String& stringToTest, const juce::String& flags)
+{
+    try
+    {
+        // Determine regex flags
+        std::regex::flag_type regexFlags = std::regex::ECMAScript; // Default syntax
+
+        if (flags.containsChar('i')) {
+            regexFlags |= std::regex::icase; // Case-insensitive
+        }
+
+        if (flags.containsChar('m')) {
+          regexFlags |= std::regex::multiline;  // Specifies that ^ shall match the beginning of a line and $ shall match the end of a line, if the ECMAScript engine is selected.
+        }
+
+        // Compile the regex with the specified flags
+        std::regex reg(regexpString.toStdString(), regexFlags);
+
+        // Perform the regex match
+        return std::regex_search(stringToTest.toStdString(), reg);
+    }
+    catch (const std::regex_error& e)
+    {
+        DBG("Regex error: " << e.what());
+        return false;
+    }
 }

--- a/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.cpp
+++ b/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.cpp
@@ -129,7 +129,7 @@ bool  StringComparator::regexpMatch(const juce::String& regexpString, const juce
         }
 
         if (flags.containsChar('m')) {
-          regexFlags |= std::regex::multiline;  // Specifies that ^ shall match the beginning of a line and $ shall match the end of a line, if the ECMAScript engine is selected.
+            regexFlags |= std::regex::multiline;  // Specifies that ^ shall match the beginning of a line and $ shall match the end of a line, if the ECMAScript engine is selected.
         }
 
         // Compile the regex with the specified flags

--- a/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.h
+++ b/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.h
@@ -19,9 +19,38 @@ public:
 
 	const Identifier equalsId = "=";
 	const Identifier differentId = "!=";
+	
 	const Identifier containsId = "contains";
-	const Identifier startsWith = "startsWith";
-	const Identifier endsWidth = "endsWidth";
+	const Identifier containsIgnoreCaseId = "containsIgnoreCase";
 
+    const Identifier regexpMatchesId = "regexpMatch";
+    const Identifier notRegexpMatchesId = "notRegexpMatch";
+
+
+	const Identifier lengthIsId = "lengthIs";
+	const Identifier lengthIsNotId = "lengthIsNot";
+	const Identifier lengthLongerThanId = "lengthLonger";
+	const Identifier lengthShorterThanId = "lengthShorter";
+
+	const Identifier notContainsId = "notContains";
+	const Identifier notContainsIgnoreCaseId = "notContainsIgnoreCase";
+	
+	const Identifier startsWithId = "startsWith";
+	const Identifier startsWithIgnoreCaseId = "startsWithIgnoreCase";
+	
+	const Identifier notStartsWithId = "notStartsWith";
+	const Identifier notStartsWithIgnoreCaseId = "notStartsWithIgnoreCase";
+	
+	const Identifier endsWithId = "endsWith";
+	const Identifier endsWithIgnoreCaseId = "endsWithIgnoreCase";
+	
+	const Identifier notEndsWithId = "notEndsWith";
+	const Identifier notEndsWithIgnoreCaseId = "notEndsWithIgnoreCase";
+	
+	
+	virtual void compareFunctionChanged() override;
+	virtual void setupReferenceParam();
 	virtual bool compareInternal(Parameter* sourceParam, int multiplexIndex) override;
+    static bool regexpMatch(const juce::String& regexpString, const juce::String& stringToTest, const juce::String& flags);
+
 };


### PR DESCRIPTION
Hi!

This is how it looks like:
![image](https://github.com/user-attachments/assets/67d8b1e9-0fa0-4a45-b7c3-21656a4d19aa)


This is my first attempt to contribute, please be gracious:-))

I'm not a cpp guru at all, so please thoroughly check if i didn't mess up anything for you.


Especially check these things:
 * If you are satisfied with the variable type conversions at the length checks
 * If you are satisfied how I copied over from NumberComparators.cpp the solution for different input parameter types (most of the inputs are string, but for the length its an int)

And for the regexp, i couldn't figure out how it would be proper to have an UI for the flags.
Now, first of all, if otherwise you are happy, then you can just merge this, and have an issue to make an UI for it later on. The flags are not the most important things, so if you have no time, just merge, we'll get back to it once upon a time:)

But if you want to spin on it a bit, then:
The regexps could have flags, I implemented two: "i" for caseinsensitivity, and "m" for multiline matching.

We could have checkboxes like this: i[X], m[X], or just a string textbox with a hint of what flags supported, it's up to you:)

Cheers!