### PR TITLE
Temporarily disable regexp flags

### DIFF
--- a/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.cpp
+++ b/Source/Common/Processor/Action/Condition/conditions/StandardCondition/Comparator/comparators/StringComparators.cpp
@@ -123,14 +123,16 @@ bool  StringComparator::regexpMatch(const juce::String& regexpString, const juce
     {
         // Determine regex flags
         std::regex::flag_type regexFlags = std::regex::ECMAScript; // Default syntax
-
+        /*
         if (flags.containsChar('i')) {
             regexFlags |= std::regex::icase; // Case-insensitive
         }
 
         if (flags.containsChar('m')) {
-            regexFlags |= std::regex::multiline;  // Specifies that ^ shall match the beginning of a line and $ shall match the end of a line, if the ECMAScript engine is selected.
+            // Beware: This is only available from C++17, this broke the windows builds back when this was written.
+            // regexFlags |= std::regex::multiline;  // Specifies that ^ shall match the beginning of a line and $ shall match the end of a line, if the ECMAScript engine is selected.
         }
+        */
 
         // Compile the regex with the specified flags
         std::regex reg(regexpString.toStdString(), regexFlags);


### PR DESCRIPTION
Hi!

Sorry about the break on windows, it seems multiline is only implemented from C++17, I'm no cpp wizard, i see that on macosx we seem to use C++11 (in the projucer file), but in the *.vcxproj-s we have  <LanguageStandard>stdcpp17</LanguageStandard>, so I don't get it. But anyhow, commented it out for now.

I also wanted to move this method to be somewhere "common" or "StringUtils" or "RegexpTool" but I had no idea where it could go, so for now I left it there. 