### PR TITLE
Exposed MQTT publish method to script

### DIFF
--- a/Source/Module/modules/mqtt/MQTTModule.h
+++ b/Source/Module/modules/mqtt/MQTTModule.h
@@ -91,6 +91,9 @@ public:
 
 	void stopClient();
 
+	//Script
+	static var publishMessageFromScript(const var::NativeFunctionArgs& args);
+
 	//mosquitto
 #if JUCE_WINDOWS
 	void on_connect(int rc) override;


### PR DESCRIPTION
This PR is about allowing MQTT topic publishing from user script. It makes local.publish() available, which calls the MQTTClientModule::publishMessage() method.