### PR TITLE
LTC Sync Tolerance

### DIFF
--- a/Source/TimeMachine/Sequence/ChataigneSequence.cpp
+++ b/Source/TimeMachine/Sequence/ChataigneSequence.cpp
@@ -32,6 +32,7 @@ ChataigneSequence::ChataigneSequence() :
 	ltcModuleTarget->canBeDisabledByUser = true;
 	ltcModuleTarget->targetType = TargetParameter::CONTAINER;
 	ltcModuleTarget->maxDefaultSearchLevel = 0;
+	ltcSyncTolerance = addFloatParameter("LTC Sync Tolerance", "The maximum time difference (in seconds) allowed between the LTC time and the sequence time before a jump is made", 0.25f, 0.05f, 1.0f);
 	ltcMode = addEnumParameter("LTC Mode", "Either receiving or sending LTC", 0);
 	ltcMode->addOption("Receive", RECEIVE)->addOption("Send", SEND)->addOption("Both", BOTH);
 	ltcSendFPS = addEnumParameter("Send FPS", "The framerate to use to send LTC");
@@ -457,7 +458,7 @@ void ChataigneSequence::onExternalParameterValueChanged(Parameter* p)
 			{
 				double time = ltcAudioModule->ltcTime->floatValue() + (syncOffset->floatValue() * (reverseOffset->boolValue() ? -1 : 1));
 				double diff = fabs(currentTime->floatValue() - time);
-				if (diff > 1) setCurrentTime(time, true, true);
+				if (diff > ltcSyncTolerance->floatValue()) setCurrentTime(time, true, true);
 			}
 		}
 	}

--- a/Source/TimeMachine/Sequence/ChataigneSequence.h
+++ b/Source/TimeMachine/Sequence/ChataigneSequence.h
@@ -37,6 +37,7 @@ public:
 
 	AudioModule* ltcAudioModule;
 	TargetParameter* ltcModuleTarget;
+	FloatParameter* ltcSyncTolerance;
 	enum LTCSyncMode { RECEIVE, SEND, BOTH};
 	EnumParameter* ltcMode;
 	EnumParameter* ltcSendFPS;


### PR DESCRIPTION
Add LTC Sync Tolerance Parameter to allow adjustable jump tolerance when syncing to sound card sources.