### PR TITLE
Add options to choose out of range behavior for LTC

### DIFF
--- a/Source/TimeMachine/Sequence/ChataigneSequence.h
+++ b/Source/TimeMachine/Sequence/ChataigneSequence.h
@@ -38,6 +38,8 @@ public:
 	AudioModule* ltcAudioModule;
 	TargetParameter* ltcModuleTarget;
 	FloatParameter* ltcSyncTolerance;
+	enum LTCOutOfRangeMode { DO_NOTHING, JUMP_TO_CLOSEST, JUMP_TO_START, JUMP_TO_END };
+	EnumParameter* ltcOutOfRangeMode;
 	enum LTCSyncMode { RECEIVE, SEND, BOTH};
 	EnumParameter* ltcMode;
 	EnumParameter* ltcSendFPS;


### PR DESCRIPTION
Add 4 options for what happens when a sequence synced to LTC receives timecode that is out of the range of the sequence (including offsets).
Options are:
1) Do nothing
2) Jump to closest (jump to either start or end depending on the timecode received)
3) Jump to 0
4) Jump to End

Also includes better auto-play functionality so that whenever valid timecode is received, the sequence will start playing (when entering into valid zone, or jumping inside valid zone, etc.)