### PR TITLE
Add off actions for conductor cues

### DIFF
--- a/Source/Common/Processor/Conductor/Conductor.cpp
+++ b/Source/Common/Processor/Conductor/Conductor.cpp
@@ -140,7 +140,10 @@ void Conductor::triggerCue(ConductorCue* cue, bool triggeredFromConductor)
 
 	if (currentCue != nullptr)
 	{
-		if (currentCue != nullptr) currentCue->setIsCurrent(false);
+	    if (currentCue != cue && currentCue->csmOff != nullptr) {
+			currentCue->csmOff->triggerAll();
+		}
+		currentCue->setIsCurrent(false);
 	}
 
 	currentCue = cue;

--- a/Source/Common/Processor/Conductor/ConductorCue.cpp
+++ b/Source/Common/Processor/Conductor/ConductorCue.cpp
@@ -12,7 +12,7 @@
 #include "TimeMachine/TimeMachineIncludes.h"
 
 ConductorCue::ConductorCue(var params, Multiplex* multiplex) :
-	Action("Cue", params, multiplex, true, false),
+	Action("Cue", params, multiplex, true, true),
 	isCurrent(false),
 	isNext(false),
 	index(-1),


### PR DESCRIPTION
Currently, conductor cues can have actions that trigger when the cue is triggered.

This quick PR adds support for actions that fire when another cue gets triggered, ending the current cue's "current" state. Off actions fire before the On actions of the next cue.

<img width="375" height="616" alt="image" src="https://github.com/user-attachments/assets/a268b111-61f9-4c26-b99f-c8b976ac39e4" />
