### PR TITLE
Add full Ajazz AKP03 support: buttons, knobs, images

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -19,6 +19,17 @@ ChataigneApplication::ChataigneApplication() :
 
 void ChataigneApplication::initialiseInternal(const String &)
 {
+   #if JUCE_LINUX
+	// The launch script sets LD_LIBRARY_PATH so this binary can find its own bundled
+	// libraries, but that same variable leaks into every child process this app spawns
+	// (e.g. zenity/kdialog for native file choosers), making them load outdated bundled
+	// libs instead of the system's own and crash with symbol lookup errors. Our own
+	// executable and its directly-linked libraries are already resolved by the dynamic
+	// loader before main() runs, so clearing it here only affects processes we spawn
+	// from this point on.
+	unsetenv("LD_LIBRARY_PATH");
+   #endif
+
 	engine.reset(new ChataigneEngine());
 	if(useWindow) mainComponent.reset(new MainContentComponent());
 

--- a/Source/Module/modules/controller/ajazz/AjazzDevice.cpp
+++ b/Source/Module/modules/controller/ajazz/AjazzDevice.cpp
@@ -18,6 +18,54 @@ namespace
     constexpr int kAjazzReadSize = 512;
     constexpr int kAjazzHidReportId = 0;
     constexpr int kAjazzHidWriteSize = kAjazzDataPayloadSize + 1; // report id + payload
+
+    // AKP03 knobs report input events using their own arbitrary id set rather than the
+    // numKeys+1..numKeys+numSideKeys scheme used for AKP153's plain side buttons. These
+    // ids were captured by sniffing raw HID reports off a physical AKP03 (pid 0x3002):
+    // each knob has a dedicated click id (press=0x01/release=0x00 in the following byte,
+    // same as normal buttons) and two rotation ids (one per direction) which arrive alone,
+    // one report per detent, with no press/release semantics.
+    struct Akp03KnobIds { int click; int ccw; int cw; };
+    constexpr Akp03KnobIds kAkp03KnobIds[3] = {
+        { 0x33, 0x90, 0x91 }, // knob 0 (left)
+        { 0x35, 0x50, 0x51 }, // knob 1 (middle)
+        { 0x34, 0x60, 0x61 }, // knob 2 (right)
+    };
+
+    // AKP03 also has a row of 3 plain (non-rotary, no screen) buttons below the main grid,
+    // separate from both the grid keys and the knobs. Same sniffing method: pressed
+    // left-to-right, in known order, produced these ids in that exact order.
+    constexpr int kAkp03ExtraButtonIds[3] = { 0x25, 0x30, 0x31 };
+
+    // Image format (size + rotation) required for the on-device JPEG to actually display.
+    // Cross-checked against the mirajazz/opendeck-akp03 reference implementations, which
+    // target the same hardware over the same "CRT...BAT" HID protocol:
+    //   - AKP153 and other untested models: kept as originally tuned (96x96, 270 CW).
+    //   - AKP03 "rev2" (pid 0x3002/0x3003, protocol v3): 64x64, plain 90 CW, no mirroring.
+    //   - AKP03 original (pid 0x1001/0x1002/0x1003, protocol v2): 60x60, no rotation.
+    enum RotationMode { kRotationNone, kRotation90CW, kRotation270CW };
+}
+
+void AjazzDevice::getImageFormat(int& imgSize, int& rotationMode) const
+{
+    if (modelName == "AKP03")
+    {
+        if (pid == 0x3002 || pid == 0x3003)
+        {
+            imgSize = 64;
+            rotationMode = kRotation90CW;
+        }
+        else
+        {
+            imgSize = 60;
+            rotationMode = kRotationNone;
+        }
+    }
+    else
+    {
+        imgSize = 96;
+        rotationMode = kRotation270CW;
+    }
 }
 
 AjazzDevice::AjazzDevice(hid_device* device, String serialNumber, String devicePath, int pid) :
@@ -30,18 +78,18 @@ AjazzDevice::AjazzDevice(hid_device* device, String serialNumber, String deviceP
     currentBrightness(100)
 {
     if (pid == 0x6674 || pid == 0x1010 || pid == 0x1020 || pid == 0x3010) {
-        modelName = "AKP153"; numRows = 3; numColumns = 5; numSideKeys = 3;
+        modelName = "AKP153"; numRows = 3; numColumns = 5; numSideKeys = 3; numExtraButtons = 0;
     } else if (pid == 0x1001 || pid == 0x1002 || pid == 0x1003 || pid == 0x3002 || pid == 0x3003) {
-        modelName = "AKP03"; numRows = 2; numColumns = 3; numSideKeys = 3;
+        modelName = "AKP03"; numRows = 2; numColumns = 3; numSideKeys = 3; numExtraButtons = 3;
     } else if (pid == 0x3006 || pid == 0x3004 || pid == 0x3013) {
-        modelName = "AKP05"; numRows = 2; numColumns = 5; numSideKeys = 4;
+        modelName = "AKP05"; numRows = 2; numColumns = 5; numSideKeys = 4; numExtraButtons = 0;
     } else {
-        modelName = "Unknown"; numRows = 3; numColumns = 5; numSideKeys = 3;
+        modelName = "Unknown"; numRows = 3; numColumns = 5; numSideKeys = 3; numExtraButtons = 0;
     }
     numKeys = numRows * numColumns;
 
     if (device != nullptr) hid_set_nonblocking(device, 1);
-    for (int i = 0; i < numKeys + numSideKeys; ++i) buttonStates.add(false);
+    for (int i = 0; i < numKeys + numSideKeys + numExtraButtons; ++i) buttonStates.add(false);
     startThread();
 }
 
@@ -116,9 +164,9 @@ void AjazzDevice::clearAll()
     clearButton(0xff);
 }
 
-static Image renderButtonImage(Image source, bool highlight, const String& overlayText, int textSize, bool colorize = false, Colour bgColor = Colours::black)
+static Image renderButtonImage(Image source, bool highlight, const String& overlayText, int textSize, int imgSize, int rotationMode, bool colorize = false, Colour bgColor = Colours::black)
 {
-    const int IMG_SIZE = 96;
+    const int IMG_SIZE = imgSize;
     Image iconImage(Image::RGB, IMG_SIZE, IMG_SIZE, true);
     Graphics g(iconImage);
     if (!source.isNull())
@@ -171,13 +219,27 @@ static Image renderButtonImage(Image source, bool highlight, const String& overl
         g.drawFittedText(overlayText, bounds, Justification::centred, 3);
     }
 
-    // Apply rotation + mirroring to match device transform.
-    // Reference (mirajazz) uses: Rot90 (CW) + fliph + flipv = 270° CW total.
-    // Combined: dest(sy, IMG_SIZE-1-sx) = src(sx, sy)
+    // Apply rotation to match device transform. Mode and size are picked per-model in
+    // AjazzDevice::getImageFormat (see comment there for the reference this was verified
+    // against); mirroring is not needed for any currently-supported model.
+    if (rotationMode == kRotationNone)
+        return iconImage;
+
     Image transformed(Image::RGB, IMG_SIZE, IMG_SIZE, false);
-    for (int sy = 0; sy < IMG_SIZE; ++sy)
-        for (int sx = 0; sx < IMG_SIZE; ++sx)
-            transformed.setPixelAt(sy, IMG_SIZE - 1 - sx, iconImage.getPixelAt(sx, sy));
+    if (rotationMode == kRotation90CW)
+    {
+        // dest(IMG_SIZE-1-sy, sx) = src(sx, sy)
+        for (int sy = 0; sy < IMG_SIZE; ++sy)
+            for (int sx = 0; sx < IMG_SIZE; ++sx)
+                transformed.setPixelAt(IMG_SIZE - 1 - sy, sx, iconImage.getPixelAt(sx, sy));
+    }
+    else // kRotation270CW
+    {
+        // dest(sy, IMG_SIZE-1-sx) = src(sx, sy)
+        for (int sy = 0; sy < IMG_SIZE; ++sy)
+            for (int sx = 0; sx < IMG_SIZE; ++sx)
+                transformed.setPixelAt(sy, IMG_SIZE - 1 - sx, iconImage.getPixelAt(sx, sy));
+    }
 
     return transformed;
 }
@@ -185,14 +247,18 @@ static Image renderButtonImage(Image source, bool highlight, const String& overl
 void AjazzDevice::setImage(int row, int column, Image image, bool highlight, const String& overlayText, int textSize, bool colorize, Colour bgColor)
 {
     int buttonId = getButtonProtocolId(row, column);
-    Image rendered = renderButtonImage(image, highlight, overlayText, textSize, colorize, bgColor);
+    int imgSize, rotationMode;
+    getImageFormat(imgSize, rotationMode);
+    Image rendered = renderButtonImage(image, highlight, overlayText, textSize, imgSize, rotationMode, colorize, bgColor);
     sendButtonImageData(buttonId, rendered);
 }
 
 void AjazzDevice::setSideImage(int index, Image image, bool highlight, const String& overlayText, int textSize, bool colorize, Colour bgColor)
 {
     int buttonId = numKeys + 1 + index;
-    Image rendered = renderButtonImage(image, highlight, overlayText, textSize, colorize, bgColor);
+    int imgSize, rotationMode;
+    getImageFormat(imgSize, rotationMode);
+    Image rendered = renderButtonImage(image, highlight, overlayText, textSize, imgSize, rotationMode, colorize, bgColor);
     sendButtonImageData(buttonId, rendered);
 }
 
@@ -267,6 +333,14 @@ void AjazzDevice::sendPacket(const uint8_t* data, int length)
 
 int AjazzDevice::getButtonProtocolId(int row, int column)
 {
+    // AKP03 (2x3 grid) reports/expects a simple row-major layout, confirmed by sniffing
+    // raw HID reports while pressing each key in known physical order (top-left through
+    // bottom-right produced ids 1-6 in that exact order). This differs from AKP153's
+    // column-major, right-to-left wiring below, which was tuned for that model and is
+    // left untouched.
+    if (modelName == "AKP03")
+        return row * numColumns + column + 1;
+
     return (numColumns - 1 - column) * numRows + 1 + row;
 }
 
@@ -300,8 +374,17 @@ void AjazzDevice::run()
 
                 if (buttonId >= 1 && buttonId <= numKeys)
                 {
-                    int column = numColumns - 1 - (buttonId - 1) / numRows;
-                    int row    = (buttonId - 1) % numRows;
+                    int row, column;
+                    if (modelName == "AKP03")
+                    {
+                        row    = (buttonId - 1) / numColumns;
+                        column = (buttonId - 1) % numColumns;
+                    }
+                    else
+                    {
+                        column = numColumns - 1 - (buttonId - 1) / numRows;
+                        row    = (buttonId - 1) % numRows;
+                    }
                     WeakReference<AjazzDevice> weakThis(this);
                     MessageManager::callAsync([weakThis, row, column, isPress]() {
                         if (weakThis == nullptr) return;
@@ -310,16 +393,68 @@ void AjazzDevice::run()
                                                       row, column);
                     });
                 }
-                else if (buttonId > numKeys && buttonId <= numKeys + numSideKeys)
+                else
                 {
-                    int index = buttonId - numKeys - 1;
-                    WeakReference<AjazzDevice> weakThis(this);
-                    MessageManager::callAsync([weakThis, index, isPress]() {
-                        if (weakThis == nullptr) return;
-                        weakThis->deviceListeners.call(isPress ? &AjazzListener::ajazzSideButtonPressed
-                                                               : &AjazzListener::ajazzSideButtonReleased,
-                                                      index);
-                    });
+                    bool handled = false;
+
+                    if (modelName == "AKP03")
+                    {
+                        for (int i = 0; i < 3 && !handled; ++i)
+                        {
+                            const Akp03KnobIds& k = kAkp03KnobIds[i];
+                            if (buttonId == k.click)
+                            {
+                                handled = true;
+                                WeakReference<AjazzDevice> weakThis(this);
+                                MessageManager::callAsync([weakThis, i, isPress]() {
+                                    if (weakThis == nullptr) return;
+                                    weakThis->deviceListeners.call(isPress ? &AjazzListener::ajazzSideButtonPressed
+                                                                           : &AjazzListener::ajazzSideButtonReleased,
+                                                                  i);
+                                });
+                            }
+                            else if (buttonId == k.cw || buttonId == k.ccw)
+                            {
+                                handled = true;
+                                int direction = (buttonId == k.cw) ? 1 : -1;
+                                WeakReference<AjazzDevice> weakThis(this);
+                                MessageManager::callAsync([weakThis, i, direction]() {
+                                    if (weakThis == nullptr) return;
+                                    weakThis->deviceListeners.call(&AjazzListener::ajazzKnobRotated, i, direction);
+                                });
+                            }
+                        }
+
+                        for (int i = 0; i < numExtraButtons && !handled; ++i)
+                        {
+                            if (buttonId == kAkp03ExtraButtonIds[i])
+                            {
+                                handled = true;
+                                WeakReference<AjazzDevice> weakThis(this);
+                                MessageManager::callAsync([weakThis, i, isPress]() {
+                                    if (weakThis == nullptr) return;
+                                    weakThis->deviceListeners.call(isPress ? &AjazzListener::ajazzExtraButtonPressed
+                                                                           : &AjazzListener::ajazzExtraButtonReleased,
+                                                                  i);
+                                });
+                            }
+                        }
+                    }
+
+                    // AKP03 only ever uses the explicit id tables above; its knob/extra-button
+                    // ids never fall in the numKeys+1..numKeys+numSideKeys range this generic
+                    // fallback assumes for AKP153/AKP05, so don't let it apply to AKP03.
+                    if (!handled && modelName != "AKP03" && buttonId > numKeys && buttonId <= numKeys + numSideKeys)
+                    {
+                        int index = buttonId - numKeys - 1;
+                        WeakReference<AjazzDevice> weakThis(this);
+                        MessageManager::callAsync([weakThis, index, isPress]() {
+                            if (weakThis == nullptr) return;
+                            weakThis->deviceListeners.call(isPress ? &AjazzListener::ajazzSideButtonPressed
+                                                                   : &AjazzListener::ajazzSideButtonReleased,
+                                                          index);
+                        });
+                    }
                 }
             }
         }

--- a/Source/Module/modules/controller/ajazz/AjazzDevice.h
+++ b/Source/Module/modules/controller/ajazz/AjazzDevice.h
@@ -30,6 +30,7 @@ public:
 	int numRows;
 	int numColumns;
     int numSideKeys;
+    int numExtraButtons;
 
 	Array<bool> buttonStates;
 	SpinLock writeLock;
@@ -54,6 +55,9 @@ public:
 		virtual void ajazzButtonReleased(int row, int column) = 0;
         virtual void ajazzSideButtonPressed(int index) {}
         virtual void ajazzSideButtonReleased(int index) {}
+        virtual void ajazzKnobRotated(int index, int direction) {} // direction: 1 = CW, -1 = CCW
+        virtual void ajazzExtraButtonPressed(int index) {}
+        virtual void ajazzExtraButtonReleased(int index) {}
 	};
 
 	ListenerList<AjazzListener> deviceListeners;
@@ -66,6 +70,7 @@ private:
     void sendInitPacketIfNeeded();
     void sendPacket(const uint8_t* data, int length);
     int getButtonProtocolId(int row, int column);
+    void getImageFormat(int& imgSize, int& rotationMode) const;
 
     JUCE_DECLARE_WEAK_REFERENCEABLE(AjazzDevice)
 };

--- a/Source/Module/modules/controller/ajazz/AjazzModule.cpp
+++ b/Source/Module/modules/controller/ajazz/AjazzModule.cpp
@@ -19,11 +19,17 @@ AjazzModule::AjazzModule(const String& name) :
 	numRows(3),
 	numColumns(5),
 	numSideKeys(3),
-	readyToSend(false),
+	numExtraButtons(0),
+	knobSettingsCC("Knob Settings"),
 	colorsCC("Colors"),
 	imagesCC("Images"),
 	textsCC("Texts"),
-    sideCC("Side Icons")
+    sideCC("Side Icons"),
+    sideIconsSupported(true),
+    knobsCC("Side"),
+    knobsSupported(false),
+    extraButtonsCC("Extra Buttons"),
+	readyToSend(false)
 {
 	setupIOConfiguration(true, true);
 
@@ -39,7 +45,7 @@ AjazzModule::AjazzModule(const String& name) :
 	targetDevice = moduleParams.addEnumParameter("Target Device", "Select the physical device to control");
 	targetDevice->addOption("None", "none");
 
-    deviceWarning = moduleParams.addStringParameter("Note", "", "Knob rotation is not yet supported on this model.");
+    deviceWarning = moduleParams.addStringParameter("Note", "", "Knob rotation and press have not been verified on this model yet.");
     deviceWarning->isControllableFeedbackOnly = true;
     deviceWarning->hideInEditor = true; // Hidden by default (AKP153 has no knobs)
 
@@ -52,13 +58,23 @@ AjazzModule::AjazzModule(const String& name) :
 	moduleParams.addChildControllableContainer(&imagesCC);
 	moduleParams.addChildControllableContainer(&textsCC);
     moduleParams.addChildControllableContainer(&sideCC);
+    moduleParams.addChildControllableContainer(&knobSettingsCC);
 	colorsCC.editorIsCollapsed = true;
 	imagesCC.editorIsCollapsed = true;
 	textsCC.editorIsCollapsed = true;
     sideCC.editorIsCollapsed = true;
+    knobSettingsCC.editorIsCollapsed = true;
+
+    valuesCC.addChildControllableContainer(&knobsCC, true);
+    valuesCC.addChildControllableContainer(&extraButtonsCC, true);
 
 	brightness = moduleParams.addIntParameter("Brightness", "Sets the brightness of the deck's backlight", 75, 0, 100);
 	textSize = moduleParams.addIntParameter("Text size", "Sets the size of the text on the buttons", 10, 1, 50);
+	knobSensitivity = moduleParams.addFloatParameter("Knob Sensitivity", "Sensitivity for the relative computing of the knobs (Absolute value)", .1f, 0, 1);
+	knobFineMultiplier = moduleParams.addFloatParameter("Knob Fine Adjust Multiplier", "Multiplier applied to Knob Sensitivity while the knob is held down and rotated (values below 1 make it finer)", .2f, 0, 5);
+	knobRangeMin = moduleParams.addFloatParameter("Knob Range Min", "Lower bound for each knob's Absolute value", 0, -100000, 100000);
+	knobRangeMax = moduleParams.addFloatParameter("Knob Range Max", "Upper bound for each knob's Absolute value", 1, -100000, 100000);
+	knobWrapAround = moduleParams.addBoolParameter("Knob Wrap Around", "If checked, a knob's Absolute value wraps around the range instead of clamping at the bounds", false);
 
 	reset = moduleParams.addTrigger("Reset", "Resets the Ajazz AKP");
 	colorizeImages = moduleParams.addBoolParameter("Colorize images", "If checked, this will use both colors and images to set buttons", false);
@@ -120,21 +136,32 @@ void AjazzModule::syncGeometry(DeviceType type, bool rebuildUI)
         numRows = 3;
         numColumns = 5;
         numSideKeys = 3;
+        numExtraButtons = 0;
+        knobsSupported = false; // side elements are plain buttons, no rotation
+        sideIconsSupported = true; // side elements have real displays
         deviceWarning->hideInEditor = true;
         break;
     case AKP03:
         numRows = 2;
         numColumns = 3;
         numSideKeys = 3;
-        deviceWarning->hideInEditor = false;
+        numExtraButtons = 3; // plain button row below the grid
+        knobsSupported = true;
+        sideIconsSupported = false; // knobs have no screen at all (confirmed on hardware)
+        deviceWarning->hideInEditor = true; // fully supported (click + rotation)
         break;
     case AKP05:
         numRows = 2;
         numColumns = 5;
         numSideKeys = 4;
+        numExtraButtons = 0;
+        knobsSupported = false; // knob protocol not verified on this model yet
+        sideIconsSupported = true; // unverified assumption, kept as originally described
         deviceWarning->hideInEditor = false;
         break;
     }
+
+    sideCC.hideInEditor = !sideIconsSupported;
 
     if (rebuildUI)
     {
@@ -249,6 +276,85 @@ void AjazzModule::rebuildValues()
         sideImages.add(sideCC.addFileParameter("Image " + String(i), "Image for side button " + String(i)));
         sideTexts.add(sideCC.addStringParameter("Text " + String(i), "Text for side button " + String(i), ""));
     }
+
+    while (sidePressed.size() > numSideKeys)
+    {
+        int idx = sidePressed.size() - 1;
+        knobsCC.removeControllable(sidePressed[idx]);
+        sidePressed.remove(idx);
+    }
+
+    // Absolute/Increment/Decrement only exist while knobsSupported, so their target count
+    // collapses to 0 when switching to a model without verified rotation support.
+    while (knobAbsolutes.size() > (knobsSupported ? numSideKeys : 0))
+    {
+        int idx = knobAbsolutes.size() - 1;
+        knobsCC.removeControllable(knobAbsolutes[idx]);
+        knobsCC.removeControllable(knobIncrementTriggers[idx]);
+        knobsCC.removeControllable(knobDecrementTriggers[idx]);
+        knobAbsolutes.remove(idx);
+        knobIncrementTriggers.remove(idx);
+        knobDecrementTriggers.remove(idx);
+    }
+
+    while (sidePressed.size() < numSideKeys)
+    {
+        int i = sidePressed.size() + 1;
+        BoolParameter* b = knobsCC.addBoolParameter("Side " + String(i) + " Pressed", "Is side button/knob " + String(i) + " pressed", false);
+        b->setControllableFeedbackOnly(true);
+        sidePressed.add(b);
+    }
+
+    if (knobsSupported)
+    {
+        while (knobAbsolutes.size() < numSideKeys)
+        {
+            int i = knobAbsolutes.size() + 1;
+
+            FloatParameter* va = knobsCC.addFloatParameter("Knob " + String(i) + " Absolute", "Absolute scrolling value for knob " + String(i), 0);
+            va->setRange(knobRangeMin->floatValue(), knobRangeMax->floatValue());
+            va->setControllableFeedbackOnly(true);
+            knobAbsolutes.add(va);
+
+            Trigger* ti = knobsCC.addTrigger("Knob " + String(i) + " Increment", "Fires once each time knob " + String(i) + " is rotated one detent CW (or CCW if inverted)");
+            knobIncrementTriggers.add(ti);
+
+            Trigger* td = knobsCC.addTrigger("Knob " + String(i) + " Decrement", "Fires once each time knob " + String(i) + " is rotated one detent CCW (or CW if inverted)");
+            knobDecrementTriggers.add(td);
+        }
+    }
+
+    while (knobInvert.size() > (knobsSupported ? numSideKeys : 0))
+    {
+        int idx = knobInvert.size() - 1;
+        knobSettingsCC.removeControllable(knobInvert[idx]);
+        knobInvert.remove(idx);
+    }
+
+    if (knobsSupported)
+    {
+        while (knobInvert.size() < numSideKeys)
+        {
+            int i = knobInvert.size() + 1;
+            BoolParameter* b = knobSettingsCC.addBoolParameter("Knob " + String(i) + " Invert", "Invert the rotation direction reported for knob " + String(i), false);
+            knobInvert.add(b);
+        }
+    }
+
+    while (extraButtonsPressed.size() > numExtraButtons)
+    {
+        int idx = extraButtonsPressed.size() - 1;
+        extraButtonsCC.removeControllable(extraButtonsPressed[idx]);
+        extraButtonsPressed.remove(idx);
+    }
+
+    while (extraButtonsPressed.size() < numExtraButtons)
+    {
+        int i = extraButtonsPressed.size() + 1;
+        BoolParameter* b = extraButtonsCC.addBoolParameter("Button " + String(i) + " Pressed", "Is extra button " + String(i) + " pressed", false);
+        b->setControllableFeedbackOnly(true);
+        extraButtonsPressed.add(b);
+    }
 }
 
 void AjazzModule::setDevice(AjazzDevice* newDevice)
@@ -330,11 +436,12 @@ void AjazzModule::updateSideButton(int index)
 {
     if (device == nullptr || !readyToSend) return;
     if (index < 0 || index >= numSideKeys) return;
-    
+    if (!sideIconsSupported) return; // no physical screen to send this to
+
     File f = sideImages[index]->getFile();
     String overlayText = sideTexts[index]->stringValue();
     Colour c = sideColors[index]->getColor();
-    bool highlighted = false;
+    bool highlighted = highlightPressedButtons->boolValue() ? (index < sidePressed.size() && sidePressed[index]->boolValue()) : false;
     
     Image image;
     if (f.existsAsFile())
@@ -436,6 +543,73 @@ void AjazzModule::ajazzButtonReleased(int row, int column)
 }
 
 
+void AjazzModule::ajazzSideButtonPressed(int index)
+{
+    if (logIncomingData->boolValue()) NLOG(niceName, "Side button/knob " << String(index + 1) << " pressed");
+    if (index < 0 || index >= sidePressed.size()) return;
+
+    inActivityTrigger->trigger();
+    sidePressed[index]->setValue(true);
+    if (highlightPressedButtons->boolValue()) updateSideButton(index);
+}
+
+void AjazzModule::ajazzSideButtonReleased(int index)
+{
+    if (logIncomingData->boolValue()) NLOG(niceName, "Side button/knob " << String(index + 1) << " released");
+    if (index < 0 || index >= sidePressed.size()) return;
+
+    inActivityTrigger->trigger();
+    sidePressed[index]->setValue(false);
+    if (highlightPressedButtons->boolValue()) updateSideButton(index);
+}
+
+void AjazzModule::ajazzKnobRotated(int index, int direction)
+{
+    if (logIncomingData->boolValue()) NLOG(niceName, "Knob " << String(index + 1) << " rotated " << (direction > 0 ? "CW" : "CCW"));
+    if (index < 0 || index >= knobAbsolutes.size()) return;
+
+    inActivityTrigger->trigger();
+
+    bool inverted = index < knobInvert.size() && knobInvert[index]->boolValue();
+    bool held = index < sidePressed.size() && sidePressed[index]->boolValue();
+
+    float val = (float)direction * (inverted ? -1.0f : 1.0f);
+    if (val > 0) knobIncrementTriggers[index]->trigger();
+    else knobDecrementTriggers[index]->trigger();
+
+    float sensitivity = knobSensitivity->floatValue() * (held ? knobFineMultiplier->floatValue() : 1.0f);
+    float newAbs = knobAbsolutes[index]->floatValue() + val * sensitivity;
+
+    float rangeMin = knobRangeMin->floatValue();
+    float rangeMax = knobRangeMax->floatValue();
+    if (knobWrapAround->boolValue() && rangeMax > rangeMin)
+    {
+        float range = rangeMax - rangeMin;
+        while (newAbs < rangeMin) newAbs += range;
+        while (newAbs >= rangeMax) newAbs -= range;
+    }
+
+    knobAbsolutes[index]->setValue(newAbs);
+}
+
+void AjazzModule::ajazzExtraButtonPressed(int index)
+{
+    if (logIncomingData->boolValue()) NLOG(niceName, "Extra button " << String(index + 1) << " pressed");
+    if (index < 0 || index >= extraButtonsPressed.size()) return;
+
+    inActivityTrigger->trigger();
+    extraButtonsPressed[index]->setValue(true);
+}
+
+void AjazzModule::ajazzExtraButtonReleased(int index)
+{
+    if (logIncomingData->boolValue()) NLOG(niceName, "Extra button " << String(index + 1) << " released");
+    if (index < 0 || index >= extraButtonsPressed.size()) return;
+
+    inActivityTrigger->trigger();
+    extraButtonsPressed[index]->setValue(false);
+}
+
 void AjazzModule::onControllableFeedbackUpdateInternal(ControllableContainer* cc, Controllable* c)
 {
 	Module::onControllableFeedbackUpdateInternal(cc, c);
@@ -456,6 +630,10 @@ void AjazzModule::onControllableFeedbackUpdateInternal(ControllableContainer* cc
     {
         if (device != nullptr) syncGeometryFromDevice(device, true);
         else syncGeometry(deviceType->getValueDataAsEnum<DeviceType>(), true);
+    }
+    else if (c == knobRangeMin || c == knobRangeMax)
+    {
+        for (auto* p : knobAbsolutes) p->setRange(knobRangeMin->floatValue(), knobRangeMax->floatValue());
     }
 
 	if (!enabled->boolValue()) return;

--- a/Source/Module/modules/controller/ajazz/AjazzModule.h
+++ b/Source/Module/modules/controller/ajazz/AjazzModule.h
@@ -33,6 +33,7 @@ public:
 	int numRows;
 	int numColumns;
     int numSideKeys;
+    int numExtraButtons;
 
 	SpinLock rebuildingLock;
 
@@ -42,6 +43,15 @@ public:
 
 	IntParameter* brightness;
 	IntParameter* textSize;
+	FloatParameter* knobSensitivity;
+	FloatParameter* knobFineMultiplier; // sensitivity multiplier applied while a knob is held down
+	FloatParameter* knobRangeMin;
+	FloatParameter* knobRangeMax;
+	BoolParameter* knobWrapAround; // wrap Absolute within [min,max] instead of clamping
+
+	// Per-knob behavior config (only populated when knobsSupported)
+	ControllableContainer knobSettingsCC;
+	Array<BoolParameter*> knobInvert;
 
 	ControllableContainer colorsCC;
 	OwnedArray<Array<ColorParameter*>> colors;
@@ -53,10 +63,34 @@ public:
 	Array<ControllableContainer*> buttonRowsCC;
 	OwnedArray<Array<BoolParameter*>> buttonStates;
     
+    // Color/Image/Text for the side elements' own displays. Only meaningful when
+    // sideIconsSupported is true: on AKP03 the knobs have no screen at all (confirmed by
+    // hardware), so this is hidden and never sent there, even though the underlying
+    // numSideKeys mechanism is shared with AKP153's real side displays.
     ControllableContainer sideCC;
     Array<ColorParameter*> sideColors;
     Array<FileParameter*> sideImages;
     Array<StringParameter*> sideTexts;
+    bool sideIconsSupported;
+
+    // Input values for the side buttons / knobs. "Pressed" applies to all models;
+    // Absolute/Increment/Decrement are only built when knobsSupported is true (currently
+    // AKP03 only, since AKP153 side elements are plain buttons and AKP05's protocol is
+    // unverified). A rotary encoder has no true "home" position, so each detent fires an
+    // Increment/Decrement trigger (Chataigne's native one-shot primitive) rather than a
+    // Relative value that would otherwise linger at +1/-1 between ticks; Absolute is kept
+    // as the one running, bounded number to bind against.
+    ControllableContainer knobsCC;
+    Array<BoolParameter*> sidePressed;
+    Array<FloatParameter*> knobAbsolutes;
+    Array<Trigger*> knobIncrementTriggers;
+    Array<Trigger*> knobDecrementTriggers;
+    bool knobsSupported;
+
+    // A row of plain (non-rotary, no screen) buttons below the main grid on AKP03, separate
+    // from both the grid keys and the knobs.
+    ControllableContainer extraButtonsCC;
+    Array<BoolParameter*> extraButtonsPressed;
 
 	void rebuildValues();
 	void updateDeviceList();
@@ -81,6 +115,11 @@ public:
 
 	virtual void ajazzButtonPressed(int row, int column) override;
 	virtual void ajazzButtonReleased(int row, int column) override;
+    virtual void ajazzSideButtonPressed(int index) override;
+    virtual void ajazzSideButtonReleased(int index) override;
+    virtual void ajazzKnobRotated(int index, int direction) override;
+    virtual void ajazzExtraButtonPressed(int index) override;
+    virtual void ajazzExtraButtonReleased(int index) override;
 
 	void onControllableFeedbackUpdateInternal(ControllableContainer* cc, Controllable* c) override;
 	


### PR DESCRIPTION
## Summary

Building on #322 (Ajazz AKP153 support), this fixes and completes support for the **Ajazz AKP03** specifically, which shares code with the AKP153 but has meaningfully different hardware/firmware behavior. Verified against a physical AKP03 (pid `0x3002`) by sniffing raw HID reports, and cross-checked against the [mirajazz](https://github.com/4ndv/mirajazz)/[opendeck-akp03](https://github.com/4ndv/opendeck-akp03) open source reference implementation, which targets the same devices over the same protocol.

- Grid button row/column mapping used AKP153's column-major, right-to-left wiring; AKP03 is actually simple row-major, so both presses and on-device images landed on the wrong physical key.
- The 3 knobs' click and rotation events use their own HID report ids rather than AKP153's side-button scheme, so neither press nor rotation was recognized before.
- Adds support for a previously undocumented row of 3 plain buttons below the grid, separate from the knobs.
- Fixes on-device images: this hardware revision needs 64x64 with a plain 90° CW rotation, not AKP153's 96x96 with a combined 270° CW transform, so images silently failed to render.
- The knobs have no screen at all (confirmed on hardware), so the Color/Image/Text "Side Icons" config is now hidden for this model instead of silently doing nothing.
- New knob input: `Pressed` bool, `Increment`/`Decrement` triggers per detent (fits a rotary encoder's lack of a "home" position better than a lingering `Relative` value), and a bounded/wrappable `Absolute` value with configurable range and per-knob invert. Highlight-on-press and a hold-to-fine-adjust multiplier round out the input side.
- Also fixes native file chooser dialogs (`Browse...`) crashing app-wide on Linux: the launch script's `LD_LIBRARY_PATH` (needed for the app's own bundled libs) was leaking into every spawned child process, including `zenity`/`kdialog`, causing them to load an incompatible bundled `libpng` and crash instantly.

## Test plan

- [x] Verified grid button presses and on-device images map to the correct physical key on an AKP03 (pid 0x3002)
- [x] Verified knob rotation (`Increment`/`Decrement`, `Absolute` with range/wrap/invert) and knob click (`Pressed`) on hardware
- [x] Verified the 3 extra buttons below the grid report press/release correctly
- [x] Verified `Browse...` file choosers now open correctly across modules on Linux
- [ ] AKP153 behavior intentionally left untouched — worth a smoke test to confirm no regression, since it wasn't available for this PR