### PR TITLE
Fix Learn assignment for module input values

### DIFF
--- a/Source/Module/ModuleManager.cpp
+++ b/Source/Module/ModuleManager.cpp
@@ -101,23 +101,15 @@ void ModuleManager::showAllValuesAndGetControllable(const StringArray& typeFilte
 
 bool ModuleManager::checkControllableIsAValue(Controllable* c)
 {
+	if (c == nullptr) return false;
+
 	ControllableContainer* cc = c->parentContainer;
 	while (cc != nullptr)
 	{
-		Module* m = dynamic_cast<Module*>(cc); //If controllable is child of a module
-
-		if (c->parentContainer == m || c->parentContainer == &m->moduleParams) return false; //If controllable is direct child of this module, or child 
-
-		if (m != nullptr)
+		if (Module* m = dynamic_cast<Module*>(cc))
 		{
-			ControllableContainer* vcc = c->parentContainer;
-			while (vcc != nullptr)
-			{
-				if (vcc == &m->valuesCC) return true; //If controllable is child of this module's valuesCC
-				vcc = vcc->parentContainer;
-			}
-
-			return false;
+			if (c->parentContainer == m || c->parentContainer == &m->moduleParams) return false;
+			return m->isControllableInValuesContainer(c);
 		}
 
 		cc = cc->parentContainer;


### PR DESCRIPTION
Fixes "Learn" not attaching a changing module input value, even with the value updating corectly. The module value check now safely locates the owning module before inspecting it and uses the existing helper for validation. Video below.

Fixes #337 

https://github.com/user-attachments/assets/32e841ca-84a2-43a1-9759-d91039386af4

