### PR TITLE
Fix MIDI Clock crashing on removal

### DIFF
--- a/Source/Module/modules/midi/MIDIClock.cpp
+++ b/Source/Module/modules/midi/MIDIClock.cpp
@@ -28,6 +28,7 @@ MIDIClockSender::MIDIClockSender() :
 
 MIDIClockSender::~MIDIClockSender()
 {
+	stop();
 }
 
 void MIDIClockSender::setBPM(double newBPM)

--- a/Source/Module/modules/midi/MIDIModule.cpp
+++ b/Source/Module/modules/midi/MIDIModule.cpp
@@ -111,6 +111,7 @@ MIDIModule::MIDIModule(const String& name, bool _useGenericControls) :
 
 MIDIModule::~MIDIModule()
 {
+	outClock.stop();
 	if (inputDevice != nullptr) inputDevice->removeMIDIInputListener(this);
 	if (outputDevice != nullptr) outputDevice->close();
 }


### PR DESCRIPTION
MIDIModule closed its MIDI output before stopping MIDIClockSender. Closing the last output user destroys the underlying MidiOutput, leaving the clock thread with a dangling pointer that it can access in sendMessageNow().

Stop the clock thread before releasing the module's MIDI devices, so its final MIDI Stop message is sent while the output is still valid. Also stop the thread in MIDIClockSender's destructor, before its members are destroyed.

Tested on Ubuntu 24.04